### PR TITLE
Fixed infinite loop for char "&" in unquoted attribute

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -483,6 +483,7 @@ class Tokenizer {
     while (strspn($tok, $stoplist) == 0 && $tok !== FALSE) {
       if ($tok == '&') {
         $val .= $this->decodeCharacterReference(TRUE);
+        $tok = $this->scanner->current();
       }
       else {
         if(strspn($tok, "\"'<=`") > 0) {

--- a/test/HTML5/Parser/TokenizerTest.php
+++ b/test/HTML5/Parser/TokenizerTest.php
@@ -379,6 +379,8 @@ class TokenizerTest extends \HTML5\Tests\TestCase {
     $reallyBad = array(
       '<foo ="bar">' => array('foo', array('=' => NULL, '"bar"' => NULL), FALSE),
       '<foo////>' => array('foo', array(), TRUE),
+      // character "&" in unquoted attribute shouldn't cause an infinite loop
+      '<foo bar=index.php?str=1&amp;id=29>' => array('foo', array('bar' => 'index.php?str=1&id=29'), FALSE),
     );
     foreach ($reallyBad as $test => $expects) {
       $events = $this->parse($test);


### PR DESCRIPTION
I discovered that my server was overloaded by Apache's threads because of infinite loops in this library. Reproducible example:

``` php
<?php
require __DIR__ . '/vendor/autoload.php';

// echo '<xmp>';
$dom = \HTML5::loadHTML(file_get_contents('test.html'));
echo HTML5::saveHTML($dom);
```

And file `test.html`

``` html
<!DOCTYPE html>
<html>
<head>
  <meta charset="utf-8" />
</head>
<body>
  <a href=index.php?str=1&id=29>Link</a>
</body>
</html>
```

There are more pages that is causing overload of my server so I checked some of them and noticed it is caused by character ampersand (no matter if it's valid entity or not) in unquoted attribute. It's possible that some another infinite loop in library exists, but I can't check all of the pages. If I discover another one infinite loop I create an issue at least :)
