### PR TITLE
Ignore attributes with illegal characters in name

### DIFF
--- a/src/HTML5/Parser/DOMTreeBuilder.php
+++ b/src/HTML5/Parser/DOMTreeBuilder.php
@@ -234,7 +234,13 @@ class DOMTreeBuilder implements EventHandler {
         $aName = Elements::normalizeMathMlAttribute($aName);
       }
 
-      $ele->setAttribute($aName, $aVal);
+      try {
+        $ele->setAttribute($aName, $aVal);
+      }
+      catch(\DOMException $e) {
+        $this->parseError("Illegal attribute name for tag $name. Ignoring: $aName");
+        continue;
+      }
 
       // This is necessary on a non-DTD schema, like HTML5.
       if ($aName == 'id') {

--- a/test/HTML5/Parser/TokenizerTest.php
+++ b/test/HTML5/Parser/TokenizerTest.php
@@ -363,10 +363,17 @@ class TokenizerTest extends \HTML5\Tests\TestCase {
       // This will emit an entity lookup failure for &red.
       "<foo a='blue&red'>" => array('foo', array('a' => 'blue&red'), FALSE),
       "<foo a='blue&&amp;&red'>" => array('foo', array('a' => 'blue&&&red'), FALSE),
-      '<foo b"="baz">' => array('foo', array('b"' => 'baz'), FALSE),
       '<foo bar=>' => array('foo', array('bar' => NULL), FALSE),
       '<foo bar="oh' => array('foo', array('bar' => 'oh'), FALSE),
       '<foo bar=oh">' => array('foo', array('bar' => 'oh"'), FALSE),
+
+      // these attributes are ignored because of current implementation
+      // of method "DOMElement::setAttribute"
+      // see issue #23: https://github.com/Masterminds/html5-php/issues/23
+      '<foo b"="baz">' => array('foo', array(), FALSE),
+      '<foo 2abc="baz">' => array('foo', array(), FALSE),
+      '<foo ?="baz">' => array('foo', array(), FALSE),
+      '<foo foo?bar="baz">' => array('foo', array(), FALSE),
 
     );
     foreach ($bad as $test => $expects) {


### PR DESCRIPTION
Hi,
I would like to fix the issue #23 ASAP, because I parse a lot of pages that throw `DOMException` related to it. I read @technosophos's [opinion](https://github.com/Masterminds/html5-php/issues/23#issuecomment-35008560) about the issue but I think there's nothing to think about because of current `DOMElement`'s implementation in PHP. Reality is that the method `DOMElement::setAttribute` throws an exception so element with the attributes like `?`, `;`, ... can't be created. That's why I implemented the other possible way - parser ignores them.

All I want is HTML parser that doesn't throw exceptions and believe we discuss to the proper solution :)
