### PR TITLE
Don't throw an exception for invalid tag names

### DIFF
--- a/src/HTML5/Parser/DOMTreeBuilder.php
+++ b/src/HTML5/Parser/DOMTreeBuilder.php
@@ -223,8 +223,14 @@ class DOMTreeBuilder implements EventHandler {
       $lname = Elements::normalizeSvgElement($lname);
     }
 
+    try {
+      $ele = $this->doc->createElement($lname);
+    }
+    catch(\DOMException $e) {
+      $this->parseError("Illegal tag name: <$lname>. Replaced with <invalid>.");
+      $ele = $this->doc->createElement('invalid');
+    }
 
-    $ele = $this->doc->createElement($lname);
     foreach ($attributes as $aName => $aVal) {
 
       if ($this->insertMode == static::IM_IN_SVG) {

--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -322,7 +322,9 @@ class Tokenizer {
     }
 
     // We know this is at least one char.
-    $name = strtolower($this->scanner->charsUntil("/> \n\f\t"));
+    $name = strtolower($this->scanner->charsWhile(
+      ":0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    ));
     $attributes = array();
     $selfClose = FALSE;
 


### PR DESCRIPTION
I simply changed tokenizer to consume only valid tag name characters and added `try-catch` block to the tree builder just to be sure.
