### PR TITLE
Custom namespaces

### DIFF
--- a/src/HTML5.php
+++ b/src/HTML5.php
@@ -158,7 +158,7 @@ class HTML5
     public function parse(\Masterminds\HTML5\Parser\InputStream $input)
     {
         $this->errors = array();
-        $events = new DOMTreeBuilder();
+        $events = new DOMTreeBuilder(FALSE, $this->options);
         $scanner = new Scanner($input);
         $parser = new Tokenizer($scanner, $events);
 
@@ -181,7 +181,7 @@ class HTML5
      */
     public function parseFragment(\Masterminds\HTML5\Parser\InputStream $input)
     {
-        $events = new DOMTreeBuilder(TRUE);
+        $events = new DOMTreeBuilder(TRUE, $this->options);
         $scanner = new Scanner($input);
         $parser = new Tokenizer($scanner, $events);
 

--- a/test/HTML5/Serializer/OutputRulesTest.php
+++ b/test/HTML5/Serializer/OutputRulesTest.php
@@ -113,6 +113,44 @@ class OutputRulesTest extends \Masterminds\HTML5\Tests\TestCase
         $this->assertEquals('<div id="foo" class="bar baz">foo bar baz</div>', stream_get_contents($stream, - 1, 0));
     }
 
+    function testSerializeWithNamespaces()
+    {
+        $this->html5 = $this->getInstance(array(
+            'xmlNamespaces' => true
+        ));
+
+        $source = '<!DOCTYPE html>
+<html><body xmlns:x="http://www.prefixed.com" id="body">
+        <a id="bar1" xmlns="bar1">
+            <b id="bar4" xmlns="bar4"><x:prefixed id="prefixed">x</x:prefixed></b>
+        </a>
+        <svg id="svg">xx</svg>
+        <c id="bar2" xmlns="bar2">xx</c>
+        <div id="div">xx</div>
+        <d id="bar3">xx</d></body>
+</html>
+';
+
+        $dom = $this->html5->loadHTML($source, array(
+            'xmlNamespaces' => true
+        ));
+
+        $stream = fopen('php://temp', 'w');
+        $r = new OutputRules($stream, $this->html5->getOptions());
+        $t = new Traverser($dom, $stream, $r, $this->html5->getOptions());
+
+        $t->walk();
+        $rendered = stream_get_contents($stream, - 1, 0);
+
+        $this->assertEquals(str_replace(array(
+            "\n",
+            "\r"
+        ), "", $rendered), str_replace(array(
+            "\n",
+            "\r"
+        ), "", $source));
+    }
+
     public function testElementWithScript()
     {
         $dom = $this->html5->loadHTML(


### PR DESCRIPTION
An extended implementation of https://github.com/Masterminds/html5-php/pull/44 that supports also custom namespace prefixes and XML style namespaces.

See here to see an example: https://github.com/goetas/html5-php/blob/custom-namespaces/test/HTML5/Parser/DOMTreeBuilderTest.php#L99
