### PR TITLE
Case insensitive tags

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -203,7 +203,9 @@ class Tokenizer
         $sequence = '</' . $this->untilTag . '>';
         $txt = '';
         $tok = $this->scanner->current();
-        while ($tok !== false && ! ($tok == '<' && ($this->sequenceMatches($sequence, false)))) {
+
+        $caseSensitive = !Elements::isHtml5Element($this->untilTag);
+        while ($tok !== false && ! ($tok == '<' && ($this->sequenceMatches($sequence, $caseSensitive)))) {
             if ($tok == '&') {
                 $txt .= $this->decodeCharacterReference();
                 $tok = $this->scanner->current();

--- a/test/HTML5/Parser/DOMTreeBuilderTest.php
+++ b/test/HTML5/Parser/DOMTreeBuilderTest.php
@@ -62,9 +62,9 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $html = "<!doctype html>
         <html>
             <head>
-                <Title>Hello, world!</Title>
+                <Title>Hello, world!</TitlE>
             </head>
-            <body>TheBody</body>
+            <body>TheBody<script>foo</script></body>
         </html>";
         $doc = $this->parse($html);
 
@@ -75,8 +75,7 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $xpath->registerNamespace( "x", "http://www.w3.org/1999/xhtml" );
 
         $this->assertEquals("Hello, world!", $xpath->query( "//x:title" )->item( 0 )->nodeValue);
-        $this->assertEquals("TheBody", $xpath->query( "//x:body" )->item( 0 )->nodeValue);
-
+        $this->assertEquals("foo", $xpath->query( "//x:script" )->item( 0 )->nodeValue);
     }
 
     public function testDocumentFakeAttrAbsence()


### PR DESCRIPTION
This should fix #63, but how to apply it only to HTML5 tags, and not to XML tags?
