### PR TITLE
Adding two options required for compatibility with 3rd party components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     }
 }

--- a/src/HTML5/Parser/DOMTreeBuilder.php
+++ b/src/HTML5/Parser/DOMTreeBuilder.php
@@ -151,13 +151,17 @@ class DOMTreeBuilder implements EventHandler
     {
         $this->options = $options;
 
-        $impl = new \DOMImplementation();
-        // XXX:
-        // Create the doctype. For now, we are always creating HTML5
-        // documents, and attempting to up-convert any older DTDs to HTML5.
-        $dt = $impl->createDocumentType('html');
-        // $this->doc = \DOMImplementation::createDocument(NULL, 'html', $dt);
-        $this->doc = $impl->createDocument(null, null, $dt);
+        if (isset($options['target'])) {
+            $this->doc = $options['target'];
+        } else {
+            $impl = new \DOMImplementation();
+            // XXX:
+            // Create the doctype. For now, we are always creating HTML5
+            // documents, and attempting to up-convert any older DTDs to HTML5.
+            $dt = $impl->createDocumentType('html');
+            // $this->doc = \DOMImplementation::createDocument(NULL, 'html', $dt);
+            $this->doc = $impl->createDocument(null, null, $dt);
+        }
         $this->errors = array();
 
         $this->current = $this->doc; // ->documentElement;
@@ -334,10 +338,10 @@ class DOMTreeBuilder implements EventHandler
                 $ele = $this->doc->importNode($frag->documentElement, true);
 
             } else {
-                if (isset($this->nsStack[0][$prefix])) {
-                    $ele = $this->doc->createElementNS($this->nsStack[0][$prefix], $lname);
-                } else {
+                if (!isset($this->nsStack[0][$prefix]) || ($prefix === "" && $this->options['implicitHtmlNamespace'])) {
                     $ele = $this->doc->createElement($lname);
+                } else {
+                    $ele = $this->doc->createElementNS($this->nsStack[0][$prefix], $lname);
                 }
             }
 

--- a/src/HTML5/Parser/DOMTreeBuilder.php
+++ b/src/HTML5/Parser/DOMTreeBuilder.php
@@ -338,7 +338,7 @@ class DOMTreeBuilder implements EventHandler
                 $ele = $this->doc->importNode($frag->documentElement, true);
 
             } else {
-                if (!isset($this->nsStack[0][$prefix]) || ($prefix === "" && isset($this->options['implicitHtmlNamespace']) && && $this->options['implicitHtmlNamespace'])) {
+                if (!isset($this->nsStack[0][$prefix]) || ($prefix === "" && isset($this->options['implicitHtmlNamespace']) && $this->options['implicitHtmlNamespace'])) {
                     $ele = $this->doc->createElement($lname);
                 } else {
                     $ele = $this->doc->createElementNS($this->nsStack[0][$prefix], $lname);

--- a/src/HTML5/Parser/DOMTreeBuilder.php
+++ b/src/HTML5/Parser/DOMTreeBuilder.php
@@ -151,8 +151,8 @@ class DOMTreeBuilder implements EventHandler
     {
         $this->options = $options;
 
-        if (isset($options['target'])) {
-            $this->doc = $options['target'];
+        if (isset($options['targetDocument'])) {
+            $this->doc = $options['targetDocument'];
         } else {
             $impl = new \DOMImplementation();
             // XXX:
@@ -338,7 +338,7 @@ class DOMTreeBuilder implements EventHandler
                 $ele = $this->doc->importNode($frag->documentElement, true);
 
             } else {
-                if (!isset($this->nsStack[0][$prefix]) || ($prefix === "" && isset($this->options['implicitHtmlNamespace']) && $this->options['implicitHtmlNamespace'])) {
+                if (!isset($this->nsStack[0][$prefix]) || ($prefix === "" && isset($this->options['disableHtmlNsInDom']) && $this->options['disableHtmlNsInDom'])) {
                     $ele = $this->doc->createElement($lname);
                 } else {
                     $ele = $this->doc->createElementNS($this->nsStack[0][$prefix], $lname);

--- a/src/HTML5/Parser/DOMTreeBuilder.php
+++ b/src/HTML5/Parser/DOMTreeBuilder.php
@@ -338,7 +338,7 @@ class DOMTreeBuilder implements EventHandler
                 $ele = $this->doc->importNode($frag->documentElement, true);
 
             } else {
-                if (!isset($this->nsStack[0][$prefix]) || ($prefix === "" && $this->options['implicitHtmlNamespace'])) {
+                if (!isset($this->nsStack[0][$prefix]) || ($prefix === "" && isset($this->options['implicitHtmlNamespace']) && && $this->options['implicitHtmlNamespace'])) {
                     $ele = $this->doc->createElement($lname);
                 } else {
                     $ele = $this->doc->createElementNS($this->nsStack[0][$prefix], $lname);


### PR DESCRIPTION
I added two new options.

These options are implemented only in [`\Masterminds\HTML5\Parser\DOMTreeBuilder`](https://github.com/PHPPowertools/html5-php/blob/master/src/HTML5/Parser/DOMTreeBuilder.php) and have the following purpose :

* `implicitHtmlNamespace` = Allows the use of createElement instead of
createElementNS for HTML elements. This is required for compatibility
with [`\PHPPowertools\DOM-Query`](https://github.com/PHPPowertools/DOM-Query) and for compatibility with [`\Symfony\Component\CssSelector\CssSelector`](https://github.com/symfony/CssSelector).

* `target` = allows an existing DOMDocument (or subclass thereof) to be
passsed to the DOMTreeBuilder instead of creating a new one. This
option is required for compatibility with [`\PHPPowertools\DOM-Query`](https://github.com/PHPPowertools/DOM-Query)