### PR TITLE
Fixed alphabet, &szlig; now can be detected

### DIFF
--- a/src/HTML5/Parser/Scanner.php
+++ b/src/HTML5/Parser/Scanner.php
@@ -11,9 +11,9 @@ class Scanner
 
     const CHARS_HEX = 'abcdefABCDEF01234567890';
 
-    const CHARS_ALNUM = 'abcdefAghijklmnopqrstuvwxyABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890';
+    const CHARS_ALNUM = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890';
 
-    const CHARS_ALPHA = 'abcdefAghijklmnopqrstuvwxyABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const CHARS_ALPHA = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
     protected $is;
 


### PR DESCRIPTION
The english alphabet does not allow the substitution of a lowercase z in place of another uppercase A.