### PR TITLE
Don't output anything on parse.

### DIFF
--- a/src/HTML5/Serializer/Traverser.php
+++ b/src/HTML5/Serializer/Traverser.php
@@ -112,7 +112,7 @@ class Traverser
                 break;
             // Currently we don't support embedding DTDs.
             default:
-                print '<!-- Skipped -->';
+                //print '<!-- Skipped -->';
                 break;
         }
     }


### PR DESCRIPTION
Printing random comments breaks our json responses, please don't do that.
