### PR TITLE
Support for PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
   - 5.5
   - 5.6
   - hhvm
+  - nightly
 
 notifications:
   irc: "irc.freenode.net#masterminds"


### PR DESCRIPTION
See: https://travis-ci.org/Masterminds/html5-php/builds/57083554

PHP interpreter| test suite results
------------ | -------------
PHP 5.6|Time: 14.27 seconds, Memory: 20.25Mb
PHP HHVM| Time: 4.64 seconds, Memory: 16.15Mb
PHP 7| Time: **157 ms**, Memory: 6.00Mb

Does it mean that PHP7 is 90x faster? :scream: :scream: :scream: :scream: :scream: 