### PR TITLE
Update composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
-  - nightly
 
 notifications:
   irc: "irc.freenode.net#masterminds"
@@ -28,4 +28,3 @@ script:
 after_script:
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] ; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] ; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi;'
-  

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php" : ">=5.3.0"
     },
     "require-dev": {
-        "satooshi/php-coveralls": "0.6.*",
+        "satooshi/php-coveralls": "1.0.*",
         "phpunit/phpunit" : "4.*",
         "sami/sami": "~2.0"
     },


### PR DESCRIPTION
Updated [satooshi/php-coveralls](https://github.com/satooshi/php-coveralls) package to 1.0.* so [guzzlehttp/guzzle](https://github.com/guzzle/guzzle) (~6.0) is used instead of old deprecated [guzzle/guzzle](https://github.com/guzzle/guzzle3) (3.9.4)

1.0 claims to still support PHP 5.3.3 and above (https://github.com/satooshi/php-coveralls/releases/tag/v1.0.0), plus this package you only use for testing anyways.