### PR TITLE
Fixes #98: a DOM is allowed within noscript tags

### DIFF
--- a/src/HTML5/Elements.php
+++ b/src/HTML5/Elements.php
@@ -24,7 +24,7 @@ class Elements
     const KNOWN_ELEMENT = 1;
 
     // From section 8.1.2: "script", "style"
-    // From 8.2.5.4.7 ("in body" insertion mode): "noembed", "noscript"
+    // From 8.2.5.4.7 ("in body" insertion mode): "noembed"
     // From 8.4 "style", "xmp", "iframe", "noembed", "noframes"
     /**
      * Indicates the contained text should be processed as raw text.
@@ -144,7 +144,7 @@ class Elements
         "meta" => 9, // NORMAL | VOID_TAG
         "meter" => 1,
         "nav" => 17, // NORMAL | AUTOCLOSE_P,
-        "noscript" => 67, // NORMAL | TEXT_RAW | BLOCK_TAG
+        "noscript" => 65, // NORMAL | BLOCK_TAG
         "object" => 1,
         "ol" => 81, // NORMAL | AUTOCLOSE_P | BLOCK_TAG
         "optgroup" => 1,

--- a/test/HTML5/Parser/DOMTreeBuilderTest.php
+++ b/test/HTML5/Parser/DOMTreeBuilderTest.php
@@ -100,7 +100,7 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $this->assertSame($doc, $targetDom);
         $this->assertEquals('html', $doc->documentElement->tagName);
     }
-    
+
     public function testDocumentFakeAttrAbsence()
     {
         $html = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><body>foo</body></html>";
@@ -495,6 +495,12 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $this->assertEmpty($this->errors);
         $noscript = $doc->getElementsByTagName('noscript')->item(0);
         $this->assertEquals('noscript', $noscript->tagName);
+
+        $html = '<!DOCTYPE html><html><body><noscript><p>No JS</p></noscript></body></html>';
+        $doc = $this->parse($html);
+        $this->assertEmpty($this->errors);
+        $p = $doc->getElementsByTagName('p')->item(0);
+        $this->assertEquals('p', $p->tagName);
     }
 
     /**


### PR DESCRIPTION
When JavaScript is disabled noscript tags become transparent to
to the DOM. For more details see:
https://w3c.github.io/html/semantics-scripting.html#the-noscript-element
While this notes limitations in the values in the head there are
different sets elsewhere such as in:
https://w3c.github.io/html/syntax.html#the-in-head-noscript-insertion-mode
Since this is not a validating parser this handling it to make it
transparent.