### PR TITLE
fix parsing of options of an optgroup

### DIFF
--- a/src/Html5/Parser/TreeBuildingRules.php
+++ b/src/Html5/Parser/TreeBuildingRules.php
@@ -76,7 +76,6 @@ class TreeBuildingRules
             case 'option':
                 return $this->closeIfCurrentMatches($new, $current, array(
                     'option',
-                    'optgroup'
                 ));
             case 'tr':
                 return $this->closeIfCurrentMatches($new, $current, array(

--- a/test/Parser/DOMTreeBuilderTest.php
+++ b/test/Parser/DOMTreeBuilderTest.php
@@ -534,4 +534,33 @@ class DOMTreeBuilderTest extends \Masterminds\Html5\Tests\TestCase
         $this->assertEquals('div', $div->tagName);
         $this->assertEquals('foo', $div->textContent);
     }
+
+    public function testSelectGroupedOptions()
+    {
+        $html = <<<EOM
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>testSelectGroupedOptions</title>
+    </head>
+    <body>
+        <select>
+            <optgroup id="first" label="first">
+                <option value="foo">foo</option>
+                <option value="bar">bar</option>
+                <option value="baz">baz</option>
+            </optgroup>
+            <optgroup id="second" label="first">
+                <option value="lorem">lorem</option>
+                <option value="ipsum">ipsum</option>
+            </optgroup>
+         </select>
+    </body>
+</html>
+EOM;
+        $dom  = $this->parse($html);
+
+        $this->assertSame(3, $dom->getElementById('first')->getElementsByTagName('option')->length);
+        $this->assertSame(2, $dom->getElementById('second')->getElementsByTagName('option')->length);
+    }
 }

--- a/test/Parser/TreeBuildingRulesTest.php
+++ b/test/Parser/TreeBuildingRulesTest.php
@@ -90,6 +90,19 @@ class TreeBuildingRulesTest extends \Masterminds\Html5\Tests\TestCase
         $this->assertEquals('dd', $list->lastChild->tagName);
     }
 
+    public function testHandleOption()
+    {
+        $html = sprintf(self::HTML_STUB, '<optgroup id="foo" label="foo" ><option value="foo" >bar</option></optgroup>');
+        $doc = $this->parse($html);
+
+        $list = $doc->getElementById('foo');
+
+        $this->assertEquals(1, $list->childNodes->length);
+        foreach ($list->childNodes as $ele) {
+            $this->assertEquals('option', $ele->tagName);
+        }
+    }
+
     public function testTable()
     {
         $html = sprintf(self::HTML_STUB, '<table><thead id="a"><th>foo<td>bar<td>baz');


### PR DESCRIPTION
hi,

options inside an optgroup are not added as children of the said group, but are added to the group's parent instead.

BR,
vkunz