### PR TITLE
Fix PHP Notice in OutputRules

### DIFF
--- a/src/HTML5/Serializer/OutputRules.php
+++ b/src/HTML5/Serializer/OutputRules.php
@@ -221,7 +221,9 @@ class OutputRules implements \Masterminds\HTML5\Serializer\RulesInterface
         $this->openTag($ele);
         if (Elements::isA($name, Elements::TEXT_RAW)) {
             foreach ($ele->childNodes as $child) {
-                $this->wr($child->data);
+                if ($child instanceof \DOMCharacterData) {
+                    $this->wr($child->data);
+                }
             }
         } else {
             // Handle children.


### PR DESCRIPTION
When outputting a `TEXT_RAW` node, OutputRules will occasionally throw the PHP Notice `Undefined property: DOMElement::$data`.

This seems to happen when processing HTML that doesn't strictly conform to spec (my test case had child nodes inside an `iframe`), however we can prevent the issue by type checking the node before accessing the `data` property