### PR TITLE
[+]: add full UTF-8 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto
+
+/bin export-ignore
+/test export-ignore
+/.scrutinizer.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/example.php
+/sami.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ language: php
 # VMs to run the tests. For more details see:
 # - http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 # - http://docs.travis-ci.com/user/workers/standard-infrastructure/
-sudo: false
+#sudo: false
+
+sudo: required
+dist: trusty
 
 git:
   depth: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ language: php
 # - http://docs.travis-ci.com/user/workers/standard-infrastructure/
 sudo: false
 
+git:
+  depth: 2
+
 php:
   - 5.3
   - 5.4
@@ -22,13 +25,14 @@ notifications:
   irc: "irc.freenode.net#masterminds"
 
 before_script:
-  - composer self-update
-  - composer install
+  - travis_retry composer self-update
+  - travis_retry composer require satooshi/php-coveralls:1.0.0
+  - travis_retry composer install
 
 script:
   - mkdir -p build/logs
-  - ./vendor/bin/phpunit --coverage-clover=coverage.xml
+  - ./vendor/bin/phpunit -c phpunit.xml.dist
 
 after_script:
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] ; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] ; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi;'
+  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] ; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ language: php
 # VMs to run the tests. For more details see:
 # - http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 # - http://docs.travis-ci.com/user/workers/standard-infrastructure/
-#sudo: false
-
-sudo: required
-dist: trusty
+sudo: false
 
 git:
   depth: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ notifications:
   irc: "irc.freenode.net#masterminds"
 
 before_script:
+  - php -r "var_dump(LIBXML_DOTTED_VERSION);"
   - travis_retry composer self-update
   - travis_retry composer require satooshi/php-coveralls:1.0.0
   - travis_retry composer install

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     ],
     "require" : {
         "ext-libxml" : "*",
-        "php" : ">=5.3.0"
+        "php" : ">=5.3.0",
+        "voku/portable-utf8": "~3.1"
     },
     "require-dev": {
-        "satooshi/php-coveralls": "1.0.*",
-        "phpunit/phpunit" : "4.*",
+        "phpunit/phpunit" : "~4.0",
         "sami/sami": "~2.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,9 @@
           <directory>test/HTML5/</directory>
         </testsuite>
     </testsuites>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
     <filter>
         <blacklist>
             <file>systemlib.phpreflection_hni</file>

--- a/src/HTML5.php
+++ b/src/HTML5.php
@@ -1,10 +1,10 @@
 <?php
 namespace Masterminds;
 
-use Masterminds\HTML5\Parser\FileInputStream;
-use Masterminds\HTML5\Parser\StringInputStream;
 use Masterminds\HTML5\Parser\DOMTreeBuilder;
+use Masterminds\HTML5\Parser\FileInputStream;
 use Masterminds\HTML5\Parser\Scanner;
+use Masterminds\HTML5\Parser\StringInputStream;
 use Masterminds\HTML5\Parser\Tokenizer;
 use Masterminds\HTML5\Serializer\OutputRules;
 use Masterminds\HTML5\Serializer\Traverser;
@@ -169,7 +169,7 @@ class HTML5
         $options = array_merge($this->getOptions(), $options);
         $events = new DOMTreeBuilder(false, $options);
         $scanner = new Scanner($input);
-        $parser = new Tokenizer($scanner, $events, !empty($options['xmlNamespaces']) ? Tokenizer::CONFORMANT_XML: Tokenizer::CONFORMANT_HTML);
+        $parser = new Tokenizer($scanner, $events, !empty($options['xmlNamespaces']) ? Tokenizer::CONFORMANT_XML : Tokenizer::CONFORMANT_HTML);
 
         $parser->parse();
         $this->errors = $events->getErrors();
@@ -188,7 +188,7 @@ class HTML5
         $options = array_merge($this->getOptions(), $options);
         $events = new DOMTreeBuilder(true, $options);
         $scanner = new Scanner($input);
-        $parser = new Tokenizer($scanner, $events, !empty($options['xmlNamespaces']) ? Tokenizer::CONFORMANT_XML: Tokenizer::CONFORMANT_HTML);
+        $parser = new Tokenizer($scanner, $events, !empty($options['xmlNamespaces']) ? Tokenizer::CONFORMANT_XML : Tokenizer::CONFORMANT_HTML);
 
         $parser->parse();
         $this->errors = $events->getErrors();
@@ -247,6 +247,6 @@ class HTML5
         $stream = fopen('php://temp', 'w');
         $this->save($dom, $stream, array_merge($this->getOptions(), $options));
 
-        return stream_get_contents($stream, - 1, 0);
+        return stream_get_contents($stream, -1, 0);
     }
 }

--- a/src/HTML5/Elements.php
+++ b/src/HTML5/Elements.php
@@ -4,6 +4,8 @@
  */
 namespace Masterminds\HTML5;
 
+use voku\helper\UTF8;
+
 /**
  * This class provides general information about HTML5 elements,
  * including syntactic and semantic issues.
@@ -504,7 +506,7 @@ class Elements
     {
         // html5 element names are case insensetitive. Forcing lowercase for the check.
         // Do we need this check or will all data passed here already be lowercase?
-        return isset(static::$html5[strtolower($name)]);
+        return isset(static::$html5[UTF8::strtolower($name)]);
     }
 
     /**
@@ -584,7 +586,7 @@ class Elements
      */
     public static function normalizeSvgElement($name)
     {
-        $name = strtolower($name);
+        $name = UTF8::strtolower($name);
         if (isset(static::$svgCaseSensitiveElementMap[$name])) {
             $name = static::$svgCaseSensitiveElementMap[$name];
         }
@@ -602,7 +604,7 @@ class Elements
      */
     public static function normalizeSvgAttribute($name)
     {
-        $name = strtolower($name);
+        $name = UTF8::strtolower($name);
         if (isset(static::$svgCaseSensitiveAttributeMap[$name])) {
             $name = static::$svgCaseSensitiveAttributeMap[$name];
         }
@@ -622,10 +624,10 @@ class Elements
      */
     public static function normalizeMathMlAttribute($name)
     {
-        $name = strtolower($name);
+        $name = UTF8::strtolower($name);
 
         // Only one attribute has a mixed case form for MathML.
-        if ($name == 'definitionurl') {
+        if ($name === 'definitionurl') {
             $name = 'definitionURL';
         }
 

--- a/src/HTML5/Parser/CharacterReference.php
+++ b/src/HTML5/Parser/CharacterReference.php
@@ -16,6 +16,7 @@ class CharacterReference
      * Given a name (e.g. 'amp'), lookup the UTF-8 character ('&')
      *
      * @param string $name <p>The name to look up.</p>
+     *
      * @return string <p>The character sequence. In UTF-8 this may be more than one byte.</p>
      */
     public static function lookupName($name)
@@ -43,6 +44,10 @@ class CharacterReference
 
     /**
      * Given a decimal number, return the UTF-8 character.
+     *
+     * @param $int
+     *
+     * @return string
      */
     public static function lookupDecimal($int)
     {
@@ -51,6 +56,10 @@ class CharacterReference
 
     /**
      * Given a hexidecimal number, return the UTF-8 character.
+     *
+     * @param $hexdec
+     *
+     * @return false|string
      */
     public static function lookupHex($hexdec)
     {

--- a/src/HTML5/Parser/FileInputStream.php
+++ b/src/HTML5/Parser/FileInputStream.php
@@ -1,5 +1,6 @@
 <?php
 namespace Masterminds\HTML5\Parser;
+use voku\helper\UTF8;
 
 /**
  * The FileInputStream loads a file to be parsed.
@@ -13,14 +14,15 @@ namespace Masterminds\HTML5\Parser;
  *
  * @todo A buffered input stream would be useful.
  */
-class FileInputStream extends StringInputStream implements InputStream
+class FileInputStream extends StringInputStream
 {
 
     /**
      * Load a file input stream.
      *
-     * @param string $data
-     *            The file or url path to load.
+     * @param string $data <p>The file or url path to load.</p>
+     * @param string $encoding
+     * @param string $debug
      */
     public function __construct($data, $encoding = 'UTF-8', $debug = '')
     {

--- a/src/HTML5/Parser/Scanner.php
+++ b/src/HTML5/Parser/Scanner.php
@@ -8,16 +8,22 @@ namespace Masterminds\HTML5\Parser;
  */
 class Scanner
 {
-
     const CHARS_HEX = 'abcdefABCDEF01234567890';
 
     const CHARS_ALNUM = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890';
 
     const CHARS_ALPHA = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
+    /**
+     * @var InputStream
+     */
     protected $is;
 
-    // Flipping this to true will give minisculely more debugging info.
+    /**
+     * Flipping this to true will give minisculely more debugging info.
+     *
+     * @var bool
+     */
     public $debug = false;
 
     /**
@@ -34,7 +40,7 @@ class Scanner
     /**
      * Get the current position.
      *
-     * @return int The current intiger byte position.
+     * @return int The current integer byte position.
      */
     public function position()
     {
@@ -62,8 +68,9 @@ class Scanner
     {
         $this->is->next();
         if ($this->is->valid()) {
-            if ($this->debug)
+            if ($this->debug) {
                 fprintf(STDOUT, "> %s\n", $this->is->current());
+            }
             return $this->is->current();
         }
 
@@ -88,6 +95,8 @@ class Scanner
 
     /**
      * Silently consume N chars.
+     *
+     * @param int $count
      */
     public function consume($count = 1)
     {
@@ -182,6 +191,10 @@ class Scanner
 
     /**
      * Read chars until something in the mask is encountered.
+     *
+     * @param $mask
+     *
+     * @return mixed
      */
     public function charsUntil($mask)
     {
@@ -190,6 +203,10 @@ class Scanner
 
     /**
      * Read chars as long as the mask matches.
+     *
+     * @param $mask
+     *
+     * @return mixed
      */
     public function charsWhile($mask)
     {

--- a/src/HTML5/Parser/StringInputStream.php
+++ b/src/HTML5/Parser/StringInputStream.php
@@ -170,7 +170,7 @@ class StringInputStream implements InputStream
             $findLengthOf = substr($this->data, 0, $this->char);
         }
 
-        return strlen($findLengthOf);
+        return UTF8::strlen($findLengthOf);
     }
 
     /**

--- a/src/HTML5/Parser/StringInputStream.php
+++ b/src/HTML5/Parser/StringInputStream.php
@@ -170,7 +170,7 @@ class StringInputStream implements InputStream
             $findLengthOf = substr($this->data, 0, $this->char);
         }
 
-        return UTF8::strlen($findLengthOf);
+        return strlen($findLengthOf);
     }
 
     /**

--- a/src/HTML5/Parser/TreeBuildingRules.php
+++ b/src/HTML5/Parser/TreeBuildingRules.php
@@ -14,7 +14,9 @@ namespace Masterminds\HTML5\Parser;
  */
 class TreeBuildingRules
 {
-
+    /**
+     * @var array
+     */
     protected static $tags = array(
         'li' => 1,
         'dd' => 1,
@@ -102,6 +104,11 @@ class TreeBuildingRules
         return $current;
     }
 
+    /**
+     * @param $ele
+     * @param $current
+     * @return mixed
+     */
     protected function handleLI($ele, $current)
     {
         return $this->closeIfCurrentMatches($ele, $current, array(
@@ -109,6 +116,11 @@ class TreeBuildingRules
         ));
     }
 
+    /**
+     * @param $ele
+     * @param $current
+     * @return mixed
+     */
     protected function handleDT($ele, $current)
     {
         return $this->closeIfCurrentMatches($ele, $current, array(
@@ -117,6 +129,11 @@ class TreeBuildingRules
         ));
     }
 
+    /**
+     * @param $ele
+     * @param $current
+     * @return mixed
+     */
     protected function handleRT($ele, $current)
     {
         return $this->closeIfCurrentMatches($ele, $current, array(
@@ -125,10 +142,15 @@ class TreeBuildingRules
         ));
     }
 
+    /**
+     * @param $ele
+     * @param $current
+     * @param $match
+     * @return mixed
+     */
     protected function closeIfCurrentMatches($ele, $current, $match)
     {
-        $tname = $current->tagName;
-        if (in_array($current->tagName, $match)) {
+        if (in_array($current->tagName, $match, true)) {
             $current->parentNode->appendChild($ele);
         } else {
             $current->appendChild($ele);

--- a/src/HTML5/Serializer/OutputRules.php
+++ b/src/HTML5/Serializer/OutputRules.php
@@ -357,6 +357,10 @@ class OutputRules implements \Masterminds\HTML5\Serializer\RulesInterface
         }
     }
 
+    /**
+     * @param $ele
+     * @return $this
+     */
     protected function attrs($ele)
     {
         // FIXME: Needs support for xml, xmlns, xlink, and namespaced elements.
@@ -394,6 +398,10 @@ class OutputRules implements \Masterminds\HTML5\Serializer\RulesInterface
         }
     }
 
+    /**
+     * @param \DOMAttr $attr
+     * @return bool
+     */
     protected function nonBooleanAttribute(\DOMAttr $attr)
     {
         $ele = $attr->ownerElement;
@@ -436,6 +444,10 @@ class OutputRules implements \Masterminds\HTML5\Serializer\RulesInterface
         return false;
     }
 
+    /**
+     * @param \DOMNode $node
+     * @return \DOMXPath
+     */
     private function getXPath(\DOMNode $node)
     {
         if (!$this->xpath) {
@@ -554,10 +566,10 @@ class OutputRules implements \Masterminds\HTML5\Serializer\RulesInterface
      *
      * @see http://www.w3.org/TR/2013/CR-html5-20130806/syntax.html#escapingString
      *
-     * @param string $text
-     *            text to escape.
-     * @param boolean $attribute
-     *            True if we are escaping an attrubute, false otherwise
+     * @param string $text <p>Text to escape.</p>
+     * @param boolean $attribute <p>True if we are escaping an attribute, false otherwise</p>
+     *
+     * @return string
      */
     protected function escape($text, $attribute = false)
     {

--- a/src/HTML5/Serializer/Traverser.php
+++ b/src/HTML5/Serializer/Traverser.php
@@ -12,39 +12,59 @@ namespace Masterminds\HTML5\Serializer;
  */
 class Traverser
 {
-
     /**
      * Namespaces that should be treated as "local" to HTML5.
      */
-    static $local_ns = array(
+    public static $local_ns = array(
         'http://www.w3.org/1999/xhtml' => 'html',
         'http://www.w3.org/1998/Math/MathML' => 'math',
         'http://www.w3.org/2000/svg' => 'svg'
     );
 
+    /**
+     * @var \DOMNode|\DOMNodeList
+     */
     protected $dom;
 
+    /**
+     * @var array
+     */
     protected $options;
 
+    /**
+     * @var bool
+     */
     protected $encode = false;
 
+    /**
+     * @var RulesInterface
+     */
     protected $rules;
 
+    /**
+     * @var resource
+     */
     protected $out;
 
     /**
      * Create a traverser.
      *
-     * @param DOMNode|DOMNodeList $dom
+     * @param \DOMNode|\DOMNodeList $dom
+     *            <p>
      *            The document or node to traverse.
+     *            </p>
      * @param resource $out
+     *            <p>
      *            A stream that allows writing. The traverser will output into this
      *            stream.
+     *            </p>
      * @param array $options
+     *            <p>
      *            An array or options for the traverser as key/value pairs. These include:
      *            - encode_entities: A bool to specify if full encding should happen for all named
      *            charachter references. Defaults to false which escapes &'<>".
      *            - output_rules: The path to the class handling the output rules.
+     *            </p>
      */
     public function __construct($dom, $out, RulesInterface $rules, $options = array())
     {
@@ -59,8 +79,7 @@ class Traverser
     /**
      * Tell the traverser to walk the DOM.
      *
-     * @return resource $out
-     *         Returns the output stream.
+     * @return resource $out <p>Returns the output stream.</p>
      */
     public function walk()
     {
@@ -87,8 +106,7 @@ class Traverser
     /**
      * Process a node in the DOM.
      *
-     * @param mixed $node
-     *            A node implementing \DOMNode.
+     * @param mixed $node <p>A node implementing \DOMNode.</p>
      */
     public function node($node)
     {
@@ -119,8 +137,7 @@ class Traverser
     /**
      * Walk through all the nodes on a node list.
      *
-     * @param \DOMNodeList $nl
-     *            A list of child elements to walk through.
+     * @param \DOMNodeList $nl <p>A list of child elements to walk through.</p>
      */
     public function children($nl)
     {
@@ -132,8 +149,7 @@ class Traverser
     /**
      * Is an element local?
      *
-     * @param mixed $ele
-     *            An element that implement \DOMNode.
+     * @param mixed $ele <p>An element that implement \DOMNode.</p>
      *
      * @return bool True if local and false otherwise.
      */

--- a/test/HTML5/ElementsTest.php
+++ b/test/HTML5/ElementsTest.php
@@ -247,9 +247,9 @@ class ElementsTest extends TestCase
     public function testIsHtml5Element()
     {
         foreach ($this->html5Elements as $element) {
-            $this->assertTrue(Elements::isHtml5Element($element), 'html5 element test failed on: ' . $element);
+            self::assertTrue(Elements::isHtml5Element($element), 'html5 element test failed on: ' . $element);
 
-            $this->assertTrue(Elements::isHtml5Element(strtoupper($element)), 'html5 element test failed on: ' . strtoupper($element));
+            self::assertTrue(Elements::isHtml5Element(strtoupper($element)), 'html5 element test failed on: ' . strtoupper($element));
         }
 
         $nonhtml5 = array(
@@ -258,19 +258,19 @@ class ElementsTest extends TestCase
             'baz'
         );
         foreach ($nonhtml5 as $element) {
-            $this->assertFalse(Elements::isHtml5Element($element), 'html5 element test failed on: ' . $element);
+            self::assertFalse(Elements::isHtml5Element($element), 'html5 element test failed on: ' . $element);
 
-            $this->assertFalse(Elements::isHtml5Element(strtoupper($element)), 'html5 element test failed on: ' . strtoupper($element));
+            self::assertFalse(Elements::isHtml5Element(strtoupper($element)), 'html5 element test failed on: ' . strtoupper($element));
         }
     }
 
     public function testIsMathMLElement()
     {
         foreach ($this->mathmlElements as $element) {
-            $this->assertTrue(Elements::isMathMLElement($element), 'MathML element test failed on: ' . $element);
+            self::assertTrue(Elements::isMathMLElement($element), 'MathML element test failed on: ' . $element);
 
             // MathML is case sensetitive so these should all fail.
-            $this->assertFalse(Elements::isMathMLElement(strtoupper($element)), 'MathML element test failed on: ' . strtoupper($element));
+            self::assertFalse(Elements::isMathMLElement(strtoupper($element)), 'MathML element test failed on: ' . strtoupper($element));
         }
 
         $nonMathML = array(
@@ -279,17 +279,17 @@ class ElementsTest extends TestCase
             'baz'
         );
         foreach ($nonMathML as $element) {
-            $this->assertFalse(Elements::isMathMLElement($element), 'MathML element test failed on: ' . $element);
+            self::assertFalse(Elements::isMathMLElement($element), 'MathML element test failed on: ' . $element);
         }
     }
 
     public function testIsSvgElement()
     {
         foreach ($this->svgElements as $element) {
-            $this->assertTrue(Elements::isSvgElement($element), 'SVG element test failed on: ' . $element);
+            self::assertTrue(Elements::isSvgElement($element), 'SVG element test failed on: ' . $element);
 
             // SVG is case sensetitive so these should all fail.
-            $this->assertFalse(Elements::isSvgElement(strtoupper($element)), 'SVG element test failed on: ' . strtoupper($element));
+            self::assertFalse(Elements::isSvgElement(strtoupper($element)), 'SVG element test failed on: ' . strtoupper($element));
         }
 
         $nonSVG = array(
@@ -298,33 +298,33 @@ class ElementsTest extends TestCase
             'baz'
         );
         foreach ($nonSVG as $element) {
-            $this->assertFalse(Elements::isSvgElement($element), 'SVG element test failed on: ' . $element);
+            self::assertFalse(Elements::isSvgElement($element), 'SVG element test failed on: ' . $element);
         }
     }
 
     public function testIsElement()
     {
         foreach ($this->html5Elements as $element) {
-            $this->assertTrue(Elements::isElement($element), 'html5 element test failed on: ' . $element);
+            self::assertTrue(Elements::isElement($element), 'html5 element test failed on: ' . $element);
 
-            $this->assertTrue(Elements::isElement(strtoupper($element)), 'html5 element test failed on: ' . strtoupper($element));
+            self::assertTrue(Elements::isElement(strtoupper($element)), 'html5 element test failed on: ' . strtoupper($element));
         }
 
         foreach ($this->mathmlElements as $element) {
-            $this->assertTrue(Elements::isElement($element), 'MathML element test failed on: ' . $element);
+            self::assertTrue(Elements::isElement($element), 'MathML element test failed on: ' . $element);
 
             // MathML is case sensetitive so these should all fail.
-            $this->assertFalse(Elements::isElement(strtoupper($element)), 'MathML element test failed on: ' . strtoupper($element));
+            self::assertFalse(Elements::isElement(strtoupper($element)), 'MathML element test failed on: ' . strtoupper($element));
         }
 
         foreach ($this->svgElements as $element) {
-            $this->assertTrue(Elements::isElement($element), 'SVG element test failed on: ' . $element);
+            self::assertTrue(Elements::isElement($element), 'SVG element test failed on: ' . $element);
 
             // SVG is case sensetitive so these should all fail. But, there is duplication
             // html5 and SVG. Since html5 is case insensetitive we need to make sure
             // it's not a html5 element first.
-            if (! in_array($element, $this->html5Elements)) {
-                $this->assertFalse(Elements::isElement(strtoupper($element)), 'SVG element test failed on: ' . strtoupper($element));
+            if (!in_array($element, $this->html5Elements, true)) {
+                self::assertFalse(Elements::isElement(strtoupper($element)), 'SVG element test failed on: ' . strtoupper($element));
             }
         }
 
@@ -334,16 +334,16 @@ class ElementsTest extends TestCase
             'baz'
         );
         foreach ($nonhtml5 as $element) {
-            $this->assertFalse(Elements::isElement($element), 'html5 element test failed on: ' . $element);
+            self::assertFalse(Elements::isElement($element), 'html5 element test failed on: ' . $element);
 
-            $this->assertFalse(Elements::isElement(strtoupper($element)), 'html5 element test failed on: ' . strtoupper($element));
+            self::assertFalse(Elements::isElement(strtoupper($element)), 'html5 element test failed on: ' . strtoupper($element));
         }
     }
 
     public function testElement()
     {
         foreach ($this->html5Elements as $element) {
-            $this->assertGreaterThan(0, Elements::element($element));
+            self::assertGreaterThan(0, Elements::element($element));
         }
         $nonhtml5 = array(
             'foo',
@@ -351,16 +351,16 @@ class ElementsTest extends TestCase
             'baz'
         );
         foreach ($nonhtml5 as $element) {
-            $this->assertFalse(Elements::element($element));
+            self::assertFalse(Elements::element($element));
         }
     }
 
     public function testIsA()
     {
-        $this->assertTrue(Elements::isA('script', Elements::KNOWN_ELEMENT));
-        $this->assertFalse(Elements::isA('scriptypoo', Elements::KNOWN_ELEMENT));
-        $this->assertTrue(Elements::isA('script', Elements::TEXT_RAW));
-        $this->assertFalse(Elements::isA('script', Elements::TEXT_RCDATA));
+        self::assertTrue(Elements::isA('script', Elements::KNOWN_ELEMENT));
+        self::assertFalse(Elements::isA('scriptypoo', Elements::KNOWN_ELEMENT));
+        self::assertTrue(Elements::isA('script', Elements::TEXT_RAW));
+        self::assertFalse(Elements::isA('script', Elements::TEXT_RCDATA));
 
         $voidElements = array(
             'area',
@@ -377,7 +377,7 @@ class ElementsTest extends TestCase
         );
 
         foreach ($voidElements as $element) {
-            $this->assertTrue(Elements::isA($element, Elements::VOID_TAG), 'Void element test failed on: ' . $element);
+            self::assertTrue(Elements::isA($element, Elements::VOID_TAG), 'Void element test failed on: ' . $element);
         }
 
         $nonVoid = array(
@@ -386,7 +386,7 @@ class ElementsTest extends TestCase
             'div'
         );
         foreach ($nonVoid as $tag) {
-            $this->assertFalse(Elements::isA($tag, Elements::VOID_TAG), 'Void element test failed on: ' . $tag);
+            self::assertFalse(Elements::isA($tag, Elements::VOID_TAG), 'Void element test failed on: ' . $tag);
         }
 
         $blockTags = array(
@@ -426,7 +426,7 @@ class ElementsTest extends TestCase
         );
 
         foreach ($blockTags as $tag) {
-            $this->assertTrue(Elements::isA($tag, Elements::BLOCK_TAG), 'Block tag test failed on: ' . $tag);
+            self::assertTrue(Elements::isA($tag, Elements::BLOCK_TAG), 'Block tag test failed on: ' . $tag);
         }
 
         $nonBlockTags = array(
@@ -435,7 +435,7 @@ class ElementsTest extends TestCase
             'label'
         );
         foreach ($nonBlockTags as $tag) {
-            $this->assertFalse(Elements::isA($tag, Elements::BLOCK_TAG), 'Block tag test failed on: ' . $tag);
+            self::assertFalse(Elements::isA($tag, Elements::BLOCK_TAG), 'Block tag test failed on: ' . $tag);
         }
     }
 
@@ -451,7 +451,7 @@ class ElementsTest extends TestCase
         );
 
         foreach ($tests as $input => $expected) {
-            $this->assertEquals($expected, Elements::normalizeSvgElement($input));
+            self::assertEquals($expected, Elements::normalizeSvgElement($input));
         }
     }
 
@@ -467,7 +467,7 @@ class ElementsTest extends TestCase
         );
 
         foreach ($tests as $input => $expected) {
-            $this->assertEquals($expected, Elements::normalizeSvgAttribute($input));
+            self::assertEquals($expected, Elements::normalizeSvgAttribute($input));
         }
     }
 
@@ -480,7 +480,7 @@ class ElementsTest extends TestCase
         );
 
         foreach ($tests as $input => $expected) {
-            $this->assertEquals($expected, Elements::normalizeMathMlAttribute($input));
+            self::assertEquals($expected, Elements::normalizeMathMlAttribute($input));
         }
     }
 }

--- a/test/HTML5/Html5Test.html
+++ b/test/HTML5/Html5Test.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Test</title>
+    <title>Test | ますだ, よしひこ</title>
   </head>
   <body>
-    <p>This is a test.</p>
+    <p class="मोनिच">This is a test. | iñtërnâtiônàlizætiøn</p>
   </body>
 </html>

--- a/test/HTML5/Html5Test.php
+++ b/test/HTML5/Html5Test.php
@@ -83,14 +83,14 @@ class Html5Test extends TestCase
     public function testLoadHTMLWithComments()
     {
         $contents = '<!--[if lte IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]-->
-<!--[if gt IE 8]> <!--><html class="no-js" lang="en"><head></head><body><白>lall</白></body><!--<![endif]-->
+<!--[if gt IE 8]> <!--><html class="no-js" lang="en"><白>lall</白><!--<![endif]-->
 </html>';
 
         $dom = $this->html5->loadHTML($contents);
         self::assertInstanceOf('\DOMDocument', $dom);
 
         $expected = '<!DOCTYPE html>
-<!--[if lte IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]--><!--[if gt IE 8]> <!--><html class="no-js" lang="en"><head></head><body><白>lall</白></body><!--<![endif]--></html>
+<!--[if lte IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]--><!--[if gt IE 8]> <!--><html class="no-js" lang="en"><白>lall</白><!--<![endif]--></html>
 ';
         self::assertEquals(
             str_replace(array("\n", "\r", "\r\n"), "", $expected),

--- a/test/HTML5/Html5Test.php
+++ b/test/HTML5/Html5Test.php
@@ -83,14 +83,14 @@ class Html5Test extends TestCase
     public function testLoadHTMLWithComments()
     {
         $contents = '<!--[if lte IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]-->
-<!--[if gt IE 8]> <!--><html class="no-js" lang="en"><白>lall</白><!--<![endif]-->
+<!--[if gt IE 8]> <!--><html class="no-js" lang="en"><head></head><body><白>lall</白></body><!--<![endif]-->
 </html>';
 
         $dom = $this->html5->loadHTML($contents);
         self::assertInstanceOf('\DOMDocument', $dom);
 
         $expected = '<!DOCTYPE html>
-<!--[if lte IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]--><!--[if gt IE 8]> <!--><html class="no-js" lang="en"><白>lall</白><!--<![endif]--></html>
+<!--[if lte IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]--><!--[if gt IE 8]> <!--><html class="no-js" lang="en"><head></head><body><白>lall</白></body><!--<![endif]--></html>
 ';
         self::assertEquals(
             str_replace(array("\n", "\r", "\r\n"), "", $expected),

--- a/test/HTML5/Html5Test.php
+++ b/test/HTML5/Html5Test.php
@@ -1,128 +1,119 @@
 <?php
 namespace Masterminds\HTML5\Tests;
 
+use Masterminds\HTML5;
+
 class Html5Test extends TestCase
 {
+
+    /**
+     * @var HTML5
+     */
+    private $html5;
 
     public function setUp()
     {
         $this->html5 = $this->getInstance();
     }
 
-    /**
-     * Parse and serialize a string.
-     */
-    protected function cycle($html)
-    {
-        $dom = $this->html5->loadHTML('<!DOCTYPE html><html><body>' . $html . '</body></html>');
-        $out = $this->html5->saveHTML($dom);
-
-        return $out;
-    }
-
-    protected function cycleFragment($fragment)
-    {
-        $dom = $this->html5->loadHTMLFragment($fragment);
-        $out = $this->html5->saveHTML($dom);
-
-        return $out;
-    }
-
     public function testLoadOptions()
     {
         // doc
         $dom = $this->html5->loadHTML($this->wrap('<t:tag/>'), array(
-                        'implicitNamespaces' => array('t' => 'http://example.com'),
-                        "xmlNamespaces" => true
+            'implicitNamespaces' => array('t' => 'http://example.com'),
+            "xmlNamespaces" => true
         ));
-        $this->assertInstanceOf('\DOMDocument', $dom);
-        $this->assertEmpty($this->html5->getErrors());
-        $this->assertFalse($this->html5->hasErrors());
+        self::assertInstanceOf('\DOMDocument', $dom);
+        self::assertEmpty($this->html5->getErrors());
+        self::assertFalse($this->html5->hasErrors());
 
-        $xpath = new \DOMXPath( $dom );
-        $xpath->registerNamespace( "t", "http://example.com" );
-        $this->assertEquals(1, $xpath->query( "//t:tag" )->length);
+        $xpath = new \DOMXPath($dom);
+        $xpath->registerNamespace("t", "http://example.com");
+        self::assertEquals(1, $xpath->query("//t:tag")->length);
 
         // doc fragment
         $frag = $this->html5->loadHTMLFragment('<t:tag/>', array(
-                        'implicitNamespaces' => array('t' => 'http://example.com'),
-                        "xmlNamespaces" => true
+            'implicitNamespaces' => array('t' => 'http://example.com'),
+            "xmlNamespaces" => true
         ));
-        $this->assertInstanceOf('\DOMDocumentFragment', $frag);
-        $this->assertEmpty($this->html5->getErrors());
-        $this->assertFalse($this->html5->hasErrors());
+        self::assertInstanceOf('\DOMDocumentFragment', $frag);
+        self::assertEmpty($this->html5->getErrors());
+        self::assertFalse($this->html5->hasErrors());
 
         $frag->ownerDocument->appendChild($frag);
-        $xpath = new \DOMXPath( $frag->ownerDocument );
-        $xpath->registerNamespace( "t", "http://example.com" );
-        $this->assertEquals(1, $xpath->query( "//t:tag" , $frag)->length);
+        $xpath = new \DOMXPath($frag->ownerDocument);
+        $xpath->registerNamespace("t", "http://example.com");
+        self::assertEquals(1, $xpath->query("//t:tag", $frag)->length);
     }
 
     public function testErrors()
     {
         $dom = $this->html5->loadHTML('<xx as>');
-        $this->assertInstanceOf('\DOMDocument', $dom);
+        self::assertInstanceOf('\DOMDocument', $dom);
 
-        $this->assertNotEmpty($this->html5->getErrors());
-        $this->assertTrue($this->html5->hasErrors());
+        self::assertNotEmpty($this->html5->getErrors());
+        self::assertTrue($this->html5->hasErrors());
     }
 
     public function testLoad()
     {
         $dom = $this->html5->load(__DIR__ . '/Html5Test.html');
-        $this->assertInstanceOf('\DOMDocument', $dom);
-        $this->assertEmpty($this->html5->getErrors());
-        $this->assertFalse($this->html5->hasErrors());
+        self::assertInstanceOf('\DOMDocument', $dom);
+        self::assertEmpty($this->html5->getErrors());
+        self::assertFalse($this->html5->hasErrors());
 
         $file = fopen(__DIR__ . '/Html5Test.html', 'r');
         $dom = $this->html5->load($file);
-        $this->assertInstanceOf('\DOMDocument', $dom);
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertInstanceOf('\DOMDocument', $dom);
+        self::assertEmpty($this->html5->getErrors());
 
         $dom = $this->html5->loadHTMLFile(__DIR__ . '/Html5Test.html');
-        $this->assertInstanceOf('\DOMDocument', $dom);
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertInstanceOf('\DOMDocument', $dom);
+        self::assertEmpty($this->html5->getErrors());
     }
 
     public function testLoadHTML()
     {
         $contents = file_get_contents(__DIR__ . '/Html5Test.html');
         $dom = $this->html5->loadHTML($contents);
-        $this->assertInstanceOf('\DOMDocument', $dom);
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertInstanceOf('\DOMDocument', $dom);
+        self::assertEmpty($this->html5->getErrors());
     }
 
     public function testLoadHTMLWithComments()
     {
         $contents = '<!--[if lte IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]-->
-<!--[if gt IE 8]> <!--><html class="no-js" lang="en"><!--<![endif]-->
+<!--[if gt IE 8]> <!--><html class="no-js" lang="en"><白>lall</白><!--<![endif]-->
 </html>';
 
         $dom = $this->html5->loadHTML($contents);
-        $this->assertInstanceOf('\DOMDocument', $dom);
+        self::assertInstanceOf('\DOMDocument', $dom);
 
         $expected = '<!DOCTYPE html>
-<!--[if lte IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]--><!--[if gt IE 8]> <!--><html class="no-js" lang="en"><!--<![endif]--></html>
+<!--[if lte IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]--><!--[if gt IE 8]> <!--><html class="no-js" lang="en"><白>lall</白><!--<![endif]--></html>
 ';
-        $this->assertEquals($expected, $this->html5->saveHTML($dom));
+        self::assertEquals(
+            str_replace(array("\n", "\r", "\r\n"), "", $expected),
+            str_replace(array("\n", "\r", "\r\n"), "", $this->html5->saveHTML($dom))
+        );
     }
 
     public function testLoadHTMLFragment()
     {
         $fragment = '<section id="Foo"><div class="Bar">Baz</div></section>';
         $dom = $this->html5->loadHTMLFragment($fragment);
-        $this->assertInstanceOf('\DOMDocumentFragment', $dom);
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertInstanceOf('\DOMDocumentFragment', $dom);
+        self::assertEmpty($this->html5->getErrors());
     }
 
     public function testSaveHTML()
     {
         $dom = $this->html5->load(__DIR__ . '/Html5Test.html');
-        $this->assertInstanceOf('\DOMDocument', $dom);
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertInstanceOf('\DOMDocument', $dom);
+        self::assertEmpty($this->html5->getErrors());
 
         $saved = $this->html5->saveHTML($dom);
-        $this->assertRegExp('|<p>This is a test.</p>|', $saved);
+        self::assertRegExp('|<p class="मोनिच">This is a test. \| iñtërnâtiônàlizætiøn</p>|', $saved);
     }
 
     public function testSaveHTMLFragment()
@@ -131,62 +122,63 @@ class Html5Test extends TestCase
         $dom = $this->html5->loadHTMLFragment($fragment);
 
         $string = $this->html5->saveHTML($dom);
-        $this->assertEquals($fragment, $string);
+        self::assertEquals($fragment, $string);
     }
 
     public function testSave()
     {
         $dom = $this->html5->load(__DIR__ . '/Html5Test.html');
-        $this->assertInstanceOf('\DOMDocument', $dom);
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertInstanceOf('\DOMDocument', $dom);
+        self::assertEmpty($this->html5->getErrors());
 
         // Test resource
         $file = fopen('php://temp', 'w');
         $this->html5->save($dom, $file);
-        $content = stream_get_contents($file, - 1, 0);
-        $this->assertRegExp('|<p>This is a test.</p>|', $content);
+        $content = stream_get_contents($file, -1, 0);
+        self::assertRegExp('|<p class="मोनिच">This is a test. \| iñtërnâtiônàlizætiøn</p>|', $content);
 
         // Test file
         $tmpfname = tempnam(sys_get_temp_dir(), "html5-php");
         $this->html5->save($dom, $tmpfname);
         $content = file_get_contents($tmpfname);
-        $this->assertRegExp('|<p>This is a test.</p>|', $content);
+        self::assertRegExp('|<p class="मोनिच">This is a test. \| iñtërnâtiônàlizætiøn</p>|', $content);
         unlink($tmpfname);
     }
 
-    // This test reads a document into a dom, turn the dom into a document,
-    // then tries to read that document again. This makes sure we are reading,
-    // and generating a document that works at a high level.
     public function testItWorks()
     {
         $dom = $this->html5->load(__DIR__ . '/Html5Test.html');
-        $this->assertInstanceOf('\DOMDocument', $dom);
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertInstanceOf('\DOMDocument', $dom);
+        self::assertEmpty($this->html5->getErrors());
 
         $saved = $this->html5->saveHTML($dom);
 
         $dom2 = $this->html5->loadHTML($saved);
-        $this->assertInstanceOf('\DOMDocument', $dom2);
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertInstanceOf('\DOMDocument', $dom2);
+        self::assertEmpty($this->html5->getErrors());
     }
 
     public function testConfig()
     {
         $html5 = $this->getInstance();
         $options = $html5->getOptions();
-        $this->assertEquals(false, $options['encode_entities']);
+        self::assertEquals(false, $options['encode_entities']);
 
         $html5 = $this->getInstance(array(
             'foo' => 'bar',
             'encode_entities' => true
         ));
         $options = $html5->getOptions();
-        $this->assertEquals('bar', $options['foo']);
-        $this->assertEquals(true, $options['encode_entities']);
+        self::assertEquals('bar', $options['foo']);
+        self::assertEquals(true, $options['encode_entities']);
 
         // Need to reset to original so future tests pass as expected.
         // $this->getInstance()->setOption('encode_entities', false);
     }
+
+    // This test reads a document into a dom, turn the dom into a document,
+    // then tries to read that document again. This makes sure we are reading,
+    // and generating a document that works at a high level.
 
     public function testSvg()
     {
@@ -208,26 +200,26 @@ class Html5Test extends TestCase
         </body>
       </html>');
 
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertEmpty($this->html5->getErrors());
 
         // Test a mixed case attribute.
         $list = $dom->getElementsByTagName('svg');
-        $this->assertNotEmpty($list->length);
+        self::assertNotEmpty($list->length);
         $svg = $list->item(0);
-        $this->assertEquals("0 0 3 2", $svg->getAttribute('viewBox'));
-        $this->assertFalse($svg->hasAttribute('viewbox'));
+        self::assertEquals("0 0 3 2", $svg->getAttribute('viewBox'));
+        self::assertFalse($svg->hasAttribute('viewbox'));
 
         // Test a mixed case tag.
         // Note: getElementsByTagName is not case sensetitive.
         $list = $dom->getElementsByTagName('textPath');
-        $this->assertNotEmpty($list->length);
+        self::assertNotEmpty($list->length);
         $textPath = $list->item(0);
-        $this->assertEquals('textPath', $textPath->tagName);
-        $this->assertNotEquals('textpath', $textPath->tagName);
+        self::assertEquals('textPath', $textPath->tagName);
+        self::assertNotEquals('textpath', $textPath->tagName);
 
         $html = $this->html5->saveHTML($dom);
-        $this->assertRegExp('|<svg width="150" height="100" viewBox="0 0 3 2">|', $html);
-        $this->assertRegExp('|<rect width="1" height="2" x="0" fill="#008d46" />|', $html);
+        self::assertRegExp('|<svg width="150" height="100" viewBox="0 0 3 2">|', $html);
+        self::assertRegExp('|<rect width="1" height="2" x="0" fill="#008d46" />|', $html);
     }
 
     public function testMathMl()
@@ -247,23 +239,23 @@ class Html5Test extends TestCase
         </body>
       </html>');
 
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertEmpty($this->html5->getErrors());
         $list = $dom->getElementsByTagName('math');
-        $this->assertNotEmpty($list->length);
+        self::assertNotEmpty($list->length);
 
         $list = $dom->getElementsByTagName('div');
-        $this->assertNotEmpty($list->length);
+        self::assertNotEmpty($list->length);
         $div = $list->item(0);
-        $this->assertEquals('http://example.com', $div->getAttribute('definitionurl'));
-        $this->assertFalse($div->hasAttribute('definitionURL'));
+        self::assertEquals('http://example.com', $div->getAttribute('definitionurl'));
+        self::assertFalse($div->hasAttribute('definitionURL'));
         $list = $dom->getElementsByTagName('csymbol');
         $csymbol = $list->item(0);
-        $this->assertEquals('http://www.example.com/mathops/multiops.html#plusminus', $csymbol->getAttribute('definitionURL'));
-        $this->assertFalse($csymbol->hasAttribute('definitionurl'));
+        self::assertEquals('http://www.example.com/mathops/multiops.html#plusminus', $csymbol->getAttribute('definitionURL'));
+        self::assertFalse($csymbol->hasAttribute('definitionurl'));
 
         $html = $this->html5->saveHTML($dom);
-        $this->assertRegExp('|<csymbol definitionURL="http://www.example.com/mathops/multiops.html#plusminus">|', $html);
-        $this->assertRegExp('|<mi>y</mi>|', $html);
+        self::assertRegExp('|<csymbol definitionURL="http://www.example.com/mathops/multiops.html#plusminus">|', $html);
+        self::assertRegExp('|<mi>y</mi>|', $html);
     }
 
     public function testUnknownElements()
@@ -280,74 +272,93 @@ class Html5Test extends TestCase
     </f:rug>
     <sarcasm>um, yeah</sarcasm>");
 
-        $this->assertEmpty($this->html5->getErrors());
+        self::assertEmpty($this->html5->getErrors());
         $markup = $this->html5->saveHTML($dom);
-        $this->assertRegExp('|<f:name>Big rectangle thing</f:name>|', $markup);
-        $this->assertRegExp('|<sarcasm>um, yeah</sarcasm>|', $markup);
+        self::assertRegExp('|<f:name>Big rectangle thing</f:name>|', $markup);
+        self::assertRegExp('|<sarcasm>um, yeah</sarcasm>|', $markup);
     }
 
     public function testElements()
     {
         // Should have content.
         $res = $this->cycle('<div>FOO</div>');
-        $this->assertRegExp('|<div>FOO</div>|', $res);
+        self::assertRegExp('|<div>FOO</div>|', $res);
 
         // Should be empty
         $res = $this->cycle('<span></span>');
-        $this->assertRegExp('|<span></span>|', $res);
+        self::assertRegExp('|<span></span>|', $res);
 
         // Should have content.
         $res = $this->cycleFragment('<div>FOO</div>');
-        $this->assertRegExp('|<div>FOO</div>|', $res);
+        self::assertRegExp('|<div>FOO</div>|', $res);
 
         // Should be empty
         $res = $this->cycleFragment('<span></span>');
-        $this->assertRegExp('|<span></span>|', $res);
+        self::assertRegExp('|<span></span>|', $res);
 
         // Elements with dashes and underscores
         $res = $this->cycleFragment('<sp-an></sp-an>');
-        $this->assertRegExp('|<sp-an></sp-an>|', $res);
+        self::assertRegExp('|<sp-an></sp-an>|', $res);
         $res = $this->cycleFragment('<sp_an></sp_an>');
-        $this->assertRegExp('|<sp_an></sp_an>|', $res);
+        self::assertRegExp('|<sp_an></sp_an>|', $res);
 
         // Should have no closing tag.
         $res = $this->cycle('<hr>');
-        $this->assertRegExp('|<hr></body>|', $res);
+        self::assertRegExp('|<hr></body>|', $res);
+    }
+
+    /**
+     * Parse and serialize a string.
+     */
+    protected function cycle($html)
+    {
+        $dom = $this->html5->loadHTML('<!DOCTYPE html><html><body>' . $html . '</body></html>');
+        $out = $this->html5->saveHTML($dom);
+
+        return $out;
+    }
+
+    protected function cycleFragment($fragment)
+    {
+        $dom = $this->html5->loadHTMLFragment($fragment);
+        $out = $this->html5->saveHTML($dom);
+
+        return $out;
     }
 
     public function testAttributes()
     {
         $res = $this->cycle('<use xlink:href="#svg-track" xmlns:xlink="http://www.w3.org/1999/xlink"></use>');
-        $this->assertContains('<use xlink:href="#svg-track" xmlns:xlink="http://www.w3.org/1999/xlink"></use>', $res);
+        self::assertContains('<use xlink:href="#svg-track" xmlns:xlink="http://www.w3.org/1999/xlink"></use>', $res);
 
         $res = $this->cycle('<div attr="val">FOO</div>');
-        $this->assertRegExp('|<div attr="val">FOO</div>|', $res);
+        self::assertRegExp('|<div attr="val">FOO</div>|', $res);
 
         // XXX: Note that spec does NOT require attrs in the same order.
         $res = $this->cycle('<div attr="val" class="even">FOO</div>');
-        $this->assertRegExp('|<div attr="val" class="even">FOO</div>|', $res);
+        self::assertRegExp('|<div attr="val" class="even">FOO</div>|', $res);
 
         $res = $this->cycle('<div xmlns:foo="http://example.com">FOO</div>');
-        $this->assertRegExp('|<div xmlns:foo="http://example.com">FOO</div>|', $res);
+        self::assertRegExp('|<div xmlns:foo="http://example.com">FOO</div>|', $res);
 
         $res = $this->cycleFragment('<div attr="val">FOO</div>');
-        $this->assertRegExp('|<div attr="val">FOO</div>|', $res);
+        self::assertRegExp('|<div attr="val">FOO</div>|', $res);
 
         // XXX: Note that spec does NOT require attrs in the same order.
         $res = $this->cycleFragment('<div attr="val" class="even">FOO</div>');
-        $this->assertRegExp('|<div attr="val" class="even">FOO</div>|', $res);
+        self::assertRegExp('|<div attr="val" class="even">FOO</div>|', $res);
 
         $res = $this->cycleFragment('<div xmlns:foo="http://example.com">FOO</div>');
-        $this->assertRegExp('|<div xmlns:foo="http://example.com">FOO</div>|', $res);
+        self::assertRegExp('|<div xmlns:foo="http://example.com">FOO</div>|', $res);
     }
 
     public function testPCData()
     {
         $res = $this->cycle('<a>This is a test.</a>');
-        $this->assertRegExp('|This is a test.|', $res);
+        self::assertRegExp('|This is a test.|', $res);
 
         $res = $this->cycleFragment('<a>This is a test.</a>');
-        $this->assertRegExp('|This is a test.|', $res);
+        self::assertRegExp('|This is a test.|', $res);
 
         $res = $this->cycle('This
       is
@@ -355,7 +366,7 @@ class Html5Test extends TestCase
       test.');
 
         // Check that newlines are there, but don't count spaces.
-        $this->assertRegExp('|This\n\s*is\n\s*a\n\s*test.|', $res);
+        self::assertRegExp('|This\n\s*is\n\s*a\n\s*test.|', $res);
 
         $res = $this->cycleFragment('This
       is
@@ -363,40 +374,40 @@ class Html5Test extends TestCase
       test.');
 
         // Check that newlines are there, but don't count spaces.
-        $this->assertRegExp('|This\n\s*is\n\s*a\n\s*test.|', $res);
+        self::assertRegExp('|This\n\s*is\n\s*a\n\s*test.|', $res);
 
         $res = $this->cycle('<a>This <em>is</em> a test.</a>');
-        $this->assertRegExp('|This <em>is</em> a test.|', $res);
+        self::assertRegExp('|This <em>is</em> a test.|', $res);
 
         $res = $this->cycleFragment('<a>This <em>is</em> a test.</a>');
-        $this->assertRegExp('|This <em>is</em> a test.|', $res);
+        self::assertRegExp('|This <em>is</em> a test.|', $res);
     }
 
     public function testUnescaped()
     {
         $res = $this->cycle('<script>2 < 1</script>');
-        $this->assertRegExp('|2 < 1|', $res);
+        self::assertRegExp('|2 < 1|', $res);
 
         $res = $this->cycle('<style>div>div>div</style>');
-        $this->assertRegExp('|div>div>div|', $res);
+        self::assertRegExp('|div>div>div|', $res);
 
         $res = $this->cycleFragment('<script>2 < 1</script>');
-        $this->assertRegExp('|2 < 1|', $res);
+        self::assertRegExp('|2 < 1|', $res);
 
         $res = $this->cycleFragment('<style>div>div>div</style>');
-        $this->assertRegExp('|div>div>div|', $res);
+        self::assertRegExp('|div>div>div|', $res);
     }
 
     public function testEntities()
     {
         $res = $this->cycle('<a>Apples &amp; bananas.</a>');
-        $this->assertRegExp('|Apples &amp; bananas.|', $res);
+        self::assertRegExp('|Apples &amp; bananas.|', $res);
 
         $res = $this->cycleFragment('<a>Apples &amp; bananas.</a>');
-        $this->assertRegExp('|Apples &amp; bananas.|', $res);
+        self::assertRegExp('|Apples &amp; bananas.|', $res);
 
         $res = $this->cycleFragment('<p>R&D</p>');
-        $this->assertRegExp('|R&amp;D|', $res);
+        self::assertRegExp('|R&amp;D|', $res);
     }
 
     public function testCaseSensitiveTags()
@@ -408,24 +419,24 @@ class Html5Test extends TestCase
             )
         );
         $out = $this->html5->saveHTML($dom);
-        $this->assertRegExp('|<html><body><Button color="red">Error</Button></body></html>|', $out);
+        self::assertRegExp('|<html><body><Button color="red">Error</Button></body></html>|', $out);
     }
 
     public function testComment()
     {
         $res = $this->cycle('a<!-- This is a test. -->b');
-        $this->assertRegExp('|<!-- This is a test. -->|', $res);
+        self::assertRegExp('|<!-- This is a test. -->|', $res);
 
         $res = $this->cycleFragment('a<!-- This is a test. -->b');
-        $this->assertRegExp('|<!-- This is a test. -->|', $res);
+        self::assertRegExp('|<!-- This is a test. -->|', $res);
     }
 
     public function testCDATA()
     {
         $res = $this->cycle('a<![CDATA[ This <is> a test. ]]>b');
-        $this->assertRegExp('|<!\[CDATA\[ This <is> a test\. \]\]>|', $res);
+        self::assertRegExp('|<!\[CDATA\[ This <is> a test\. \]\]>|', $res);
 
         $res = $this->cycleFragment('a<![CDATA[ This <is> a test. ]]>b');
-        $this->assertRegExp('|<!\[CDATA\[ This <is> a test\. \]\]>|', $res);
+        self::assertRegExp('|<!\[CDATA\[ This <is> a test\. \]\]>|', $res);
     }
 }

--- a/test/HTML5/Parser/CharacterReferenceTest.php
+++ b/test/HTML5/Parser/CharacterReferenceTest.php
@@ -12,33 +12,35 @@ class CharacterReferenceTest extends \Masterminds\HTML5\Tests\TestCase
 
     public function testLookupName()
     {
-        $this->assertEquals('&', CharacterReference::lookupName('amp'));
-        $this->assertEquals('<', CharacterReference::lookupName('lt'));
-        $this->assertEquals('>', CharacterReference::lookupName('gt'));
-        $this->assertEquals('"', CharacterReference::lookupName('quot'));
-        $this->assertEquals('∌', CharacterReference::lookupName('NotReverseElement'));
+        for ($i = 0; $i <= 2; $i++) { // keep the loop for quick perf-test
+            self::assertEquals('&', CharacterReference::lookupName('amp'));
+            self::assertEquals('<', CharacterReference::lookupName('lt'));
+            self::assertEquals('>', CharacterReference::lookupName('gt'));
+            self::assertEquals('"', CharacterReference::lookupName('quot'));
+            self::assertEquals('∌', CharacterReference::lookupName('NotReverseElement'));
 
-        $this->assertNull(CharacterReference::lookupName('StinkyCheese'));
+            self::assertNull(CharacterReference::lookupName('StinkyCheese'));
+        }
     }
 
     public function testLookupHex()
     {
-        $this->assertEquals('<', CharacterReference::lookupHex('3c'));
-        $this->assertEquals('<', CharacterReference::lookupHex('003c'));
-        $this->assertEquals('&', CharacterReference::lookupHex('26'));
-        $this->assertEquals('}', CharacterReference::lookupHex('7d'));
-        $this->assertEquals('Σ', CharacterReference::lookupHex('3A3'));
-        $this->assertEquals('Σ', CharacterReference::lookupHex('03A3'));
-        $this->assertEquals('Σ', CharacterReference::lookupHex('3a3'));
-        $this->assertEquals('Σ', CharacterReference::lookupHex('03a3'));
+        self::assertEquals('<', CharacterReference::lookupHex('3c'));
+        self::assertEquals('<', CharacterReference::lookupHex('003c'));
+        self::assertEquals('&', CharacterReference::lookupHex('26'));
+        self::assertEquals('}', CharacterReference::lookupHex('7d'));
+        self::assertEquals('Σ', CharacterReference::lookupHex('3A3'));
+        self::assertEquals('Σ', CharacterReference::lookupHex('03A3'));
+        self::assertEquals('Σ', CharacterReference::lookupHex('3a3'));
+        self::assertEquals('Σ', CharacterReference::lookupHex('03a3'));
     }
 
     public function testLookupDecimal()
     {
-        $this->assertEquals('&', CharacterReference::lookupDecimal(38));
-        $this->assertEquals('&', CharacterReference::lookupDecimal('38'));
-        $this->assertEquals('<', CharacterReference::lookupDecimal(60));
-        $this->assertEquals('Σ', CharacterReference::lookupDecimal(931));
-        $this->assertEquals('Σ', CharacterReference::lookupDecimal('0931'));
+        self::assertEquals('&', CharacterReference::lookupDecimal(38));
+        self::assertEquals('&', CharacterReference::lookupDecimal('38'));
+        self::assertEquals('<', CharacterReference::lookupDecimal(60));
+        self::assertEquals('Σ', CharacterReference::lookupDecimal(931));
+        self::assertEquals('Σ', CharacterReference::lookupDecimal('0931'));
     }
 }

--- a/test/HTML5/Parser/DOMTreeBuilderTest.php
+++ b/test/HTML5/Parser/DOMTreeBuilderTest.php
@@ -5,19 +5,28 @@
  */
 namespace Masterminds\HTML5\Tests\Parser;
 
-use Masterminds\HTML5\Parser\StringInputStream;
-use Masterminds\HTML5\Parser\Scanner;
-use Masterminds\HTML5\Parser\Tokenizer;
 use Masterminds\HTML5\Parser\DOMTreeBuilder;
+use Masterminds\HTML5\Parser\Scanner;
+use Masterminds\HTML5\Parser\StringInputStream;
+use Masterminds\HTML5\Parser\Tokenizer;
 
 /**
  * These tests are functional, not necessarily unit tests.
  */
 class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
 {
+    /**
+     * @var array
+     */
     protected $errors = array();
+
     /**
      * Convenience function for parsing.
+     *
+     * @param $string
+     * @param array $options
+     *
+     * @return \DOMDocument
      */
     protected function parse($string, array $options = array())
     {
@@ -53,9 +62,9 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $html = "<!DOCTYPE html><html></html>";
         $doc = $this->parse($html);
 
-        $this->assertInstanceOf('\DOMDocument', $doc);
-        $this->assertEquals('html', $doc->documentElement->tagName);
-        $this->assertEquals('http://www.w3.org/1999/xhtml', $doc->documentElement->namespaceURI);
+        self::assertInstanceOf('\DOMDocument', $doc);
+        self::assertEquals('html', $doc->documentElement->tagName);
+        self::assertEquals('http://www.w3.org/1999/xhtml', $doc->documentElement->namespaceURI);
     }
 
     public function testStrangeCapitalization()
@@ -69,14 +78,14 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         </html>";
         $doc = $this->parse($html);
 
-        $this->assertInstanceOf('\DOMDocument', $doc);
-        $this->assertEquals('html', $doc->documentElement->tagName);
+        self::assertInstanceOf('\DOMDocument', $doc);
+        self::assertEquals('html', $doc->documentElement->tagName);
 
-        $xpath = new \DOMXPath( $doc );
-        $xpath->registerNamespace( "x", "http://www.w3.org/1999/xhtml" );
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace("x", "http://www.w3.org/1999/xhtml");
 
-        $this->assertEquals("Hello, world!", $xpath->query( "//x:title" )->item( 0 )->nodeValue);
-        $this->assertEquals("foo", $xpath->query( "//x:script" )->item( 0 )->nodeValue);
+        self::assertEquals("Hello, world!", $xpath->query("//x:title")->item(0)->nodeValue);
+        self::assertEquals("foo", $xpath->query("//x:script")->item(0)->nodeValue);
     }
 
     public function testDocumentWithDisabledNamespaces()
@@ -84,9 +93,9 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $html = "<!DOCTYPE html><html></html>";
         $doc = $this->parse($html, array('disable_html_ns' => true));
 
-        $this->assertInstanceOf('\DOMDocument', $doc);
-        $this->assertEquals('html', $doc->documentElement->tagName);
-        $this->assertNull($doc->documentElement->namespaceURI);
+        self::assertInstanceOf('\DOMDocument', $doc);
+        self::assertEquals('html', $doc->documentElement->tagName);
+        self::assertNull($doc->documentElement->namespaceURI);
     }
 
     public function testDocumentWithATargetDocument()
@@ -96,18 +105,18 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $html = "<!DOCTYPE html><html></html>";
         $doc = $this->parse($html, array('target_document' => $targetDom));
 
-        $this->assertInstanceOf('\DOMDocument', $doc);
-        $this->assertSame($doc, $targetDom);
-        $this->assertEquals('html', $doc->documentElement->tagName);
+        self::assertInstanceOf('\DOMDocument', $doc);
+        self::assertSame($doc, $targetDom);
+        self::assertEquals('html', $doc->documentElement->tagName);
     }
 
     public function testDocumentFakeAttrAbsence()
     {
         $html = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><body>foo</body></html>";
-        $doc = $this->parse($html, array('xmlNamespaces'=>true));
+        $doc = $this->parse($html, array('xmlNamespaces' => true));
 
         $xp = new \DOMXPath($doc);
-        $this->assertEquals(0, $xp->query("//@html5-php-fake-id-attribute")->length);
+        self::assertEquals(0, $xp->query("//@html5-php-fake-id-attribute")->length);
     }
 
     public function testFragment()
@@ -115,12 +124,12 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $html = "<div>test</div><span>test2</span>";
         $doc = $this->parseFragment($html);
 
-        $this->assertInstanceOf('\DOMDocumentFragment', $doc);
-        $this->assertTrue($doc->hasChildNodes());
-        $this->assertEquals('div', $doc->childNodes->item(0)->tagName);
-        $this->assertEquals('test', $doc->childNodes->item(0)->textContent);
-        $this->assertEquals('span', $doc->childNodes->item(1)->tagName);
-        $this->assertEquals('test2', $doc->childNodes->item(1)->textContent);
+        self::assertInstanceOf('\DOMDocumentFragment', $doc);
+        self::assertTrue($doc->hasChildNodes());
+        self::assertEquals('div', $doc->childNodes->item(0)->tagName);
+        self::assertEquals('test', $doc->childNodes->item(0)->textContent);
+        self::assertEquals('span', $doc->childNodes->item(1)->tagName);
+        self::assertEquals('test2', $doc->childNodes->item(1)->textContent);
     }
 
     public function testElements()
@@ -129,19 +138,19 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $doc = $this->parse($html);
         $root = $doc->documentElement;
 
-        $this->assertEquals('html', $root->tagName);
-        $this->assertEquals('html', $root->localName);
-        $this->assertEquals('html', $root->nodeName);
+        self::assertEquals('html', $root->tagName);
+        self::assertEquals('html', $root->localName);
+        self::assertEquals('html', $root->nodeName);
 
-        $this->assertEquals(2, $root->childNodes->length);
+        self::assertEquals(2, $root->childNodes->length);
         $kids = $root->childNodes;
 
-        $this->assertEquals('head', $kids->item(0)->tagName);
-        $this->assertEquals('body', $kids->item(1)->tagName);
+        self::assertEquals('head', $kids->item(0)->tagName);
+        self::assertEquals('body', $kids->item(1)->tagName);
 
         $head = $kids->item(0);
-        $this->assertEquals(1, $head->childNodes->length);
-        $this->assertEquals('title', $head->childNodes->item(0)->tagName);
+        self::assertEquals(1, $head->childNodes->length);
+        self::assertEquals('title', $head->childNodes->item(0)->tagName);
     }
 
     public function testImplicitNamespaces()
@@ -149,12 +158,12 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $dom = $this->parse('<!DOCTYPE html><html><body><a xlink:href="bar">foo</a></body></html>');
         $a = $dom->getElementsByTagName('a')->item(0);
         $attr = $a->getAttributeNode('xlink:href');
-        $this->assertEquals('http://www.w3.org/1999/xlink', $attr->namespaceURI);
+        self::assertEquals('http://www.w3.org/1999/xlink', $attr->namespaceURI);
 
         $dom = $this->parse('<!DOCTYPE html><html><body><a xml:base="bar">foo</a></body></html>');
         $a = $dom->getElementsByTagName('a')->item(0);
         $attr = $a->getAttributeNode('xml:base');
-        $this->assertEquals('http://www.w3.org/XML/1998/namespace', $attr->namespaceURI);
+        self::assertEquals('http://www.w3.org/XML/1998/namespace', $attr->namespaceURI);
     }
 
     public function testCustomImplicitNamespaces()
@@ -166,7 +175,7 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         ));
         $a = $dom->getElementsByTagName('a')->item(0);
         $attr = $a->getAttributeNode('t:href');
-        $this->assertEquals('http://www.example.com', $attr->namespaceURI);
+        self::assertEquals('http://www.example.com', $attr->namespaceURI);
 
         $dom = $this->parse('<!DOCTYPE html><html><body><t:a>foo</t:a></body></html>', array(
             'implicitNamespaces' => array(
@@ -174,7 +183,7 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
             )
         ));
         $list = $dom->getElementsByTagNameNS('http://www.example.com', 'a');
-        $this->assertEquals(1, $list->length);
+        self::assertEquals(1, $list->length);
     }
 
     public function testXmlNamespaces()
@@ -186,14 +195,14 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
             </body>
             <div>foo</div>
           </html>', array(
-                'xmlNamespaces' => true
-            ));
+            'xmlNamespaces' => true
+        ));
         $a = $dom->getElementsByTagName('a')->item(0);
         $attr = $a->getAttributeNode('t:href');
-        $this->assertEquals('http://www.example.com', $attr->namespaceURI);
+        self::assertEquals('http://www.example.com', $attr->namespaceURI);
 
         $list = $dom->getElementsByTagNameNS('http://www.example.com', 'body');
-        $this->assertEquals(1, $list->length);
+        self::assertEquals(1, $list->length);
     }
 
     public function testXmlNamespaceNesting()
@@ -211,50 +220,50 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
                 <xn:d xmlns:xn="http://www.prefixed.com/xn" xmlns="http://www.prefixed.com/bar5_x" id="bar5"><x id="bar5_x"/></xn:d>
             </body>
           </html>', array(
-                'xmlNamespaces' => true
-            ));
+            'xmlNamespaces' => true
+        ));
 
 
-        $this->assertEmpty($this->errors);
+        self::assertEmpty($this->errors);
 
         $div = $dom->getElementById('div');
-        $this->assertEquals('http://www.w3.org/1999/xhtml', $div->namespaceURI);
+        self::assertEquals('http://www.w3.org/1999/xhtml', $div->namespaceURI);
 
         $body = $dom->getElementById('body');
-        $this->assertEquals('http://www.w3.org/1999/xhtml', $body->namespaceURI);
+        self::assertEquals('http://www.w3.org/1999/xhtml', $body->namespaceURI);
 
         $bar1 = $dom->getElementById('bar1');
-        $this->assertEquals('http://www.prefixed.com/bar1', $bar1->namespaceURI);
+        self::assertEquals('http://www.prefixed.com/bar1', $bar1->namespaceURI);
 
         $bar2 = $dom->getElementById('bar2');
-        $this->assertEquals("http://www.prefixed.com/bar2", $bar2->namespaceURI);
+        self::assertEquals("http://www.prefixed.com/bar2", $bar2->namespaceURI);
 
         $bar3 = $dom->getElementById('bar3');
-        $this->assertEquals("http://www.w3.org/1999/xhtml", $bar3->namespaceURI);
+        self::assertEquals("http://www.w3.org/1999/xhtml", $bar3->namespaceURI);
 
         $bar4 = $dom->getElementById('bar4');
-        $this->assertEquals("http://www.prefixed.com/bar4", $bar4->namespaceURI);
+        self::assertEquals("http://www.prefixed.com/bar4", $bar4->namespaceURI);
 
         $svg = $dom->getElementById('svg');
-        $this->assertEquals("http://www.w3.org/2000/svg", $svg->namespaceURI);
+        self::assertEquals("http://www.w3.org/2000/svg", $svg->namespaceURI);
 
         $prefixed = $dom->getElementById('prefixed');
-        $this->assertEquals("http://www.prefixed.com", $prefixed->namespaceURI);
+        self::assertEquals("http://www.prefixed.com", $prefixed->namespaceURI);
 
         $prefixed = $dom->getElementById('bar5');
-        $this->assertEquals("http://www.prefixed.com/xn", $prefixed->namespaceURI);
+        self::assertEquals("http://www.prefixed.com/xn", $prefixed->namespaceURI);
 
         $prefixed = $dom->getElementById('bar5_x');
-        $this->assertEquals("http://www.prefixed.com/bar5_x", $prefixed->namespaceURI);
+        self::assertEquals("http://www.prefixed.com/bar5_x", $prefixed->namespaceURI);
     }
 
     public function testMoveNonInlineElements()
     {
-    	$doc = $this->parse('<p>line1<br/><hr/>line2</p>');
-		$this->assertEquals('<html xmlns="http://www.w3.org/1999/xhtml"><p>line1<br/></p><hr/>line2</html>', $doc->saveXML($doc->documentElement), 'Move non-inline elements outside of inline containers.');
+        $doc = $this->parse('<p>line1<br/><hr/>line2</p>');
+        self::assertEquals('<html xmlns="http://www.w3.org/1999/xhtml"><p>line1<br/></p><hr/>line2</html>', $doc->saveXML($doc->documentElement), 'Move non-inline elements outside of inline containers.');
 
-		$doc = $this->parse('<p>line1<div>line2</div></p>');
-		$this->assertEquals('<html xmlns="http://www.w3.org/1999/xhtml"><p>line1</p><div>line2</div></html>', $doc->saveXML($doc->documentElement), 'Move non-inline elements outside of inline containers.');
+        $doc = $this->parse('<p>line1<div>line2</div></p>');
+        self::assertEquals('<html xmlns="http://www.w3.org/1999/xhtml"><p>line1</p><div>line2</div></html>', $doc->saveXML($doc->documentElement), 'Move non-inline elements outside of inline containers.');
     }
 
     public function testAttributes()
@@ -262,20 +271,21 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $html = "<!DOCTYPE html>
       <html>
       <head><title></title></head>
-      <body id='a' class='b c'></body>
+      <body id='a' data-iñtërnâtiônàlizætiøn='ñø' class='b c'></body>
       </html>";
         $doc = $this->parse($html);
         $root = $doc->documentElement;
 
-        $body = $root->GetElementsByTagName('body')->item(0);
-        $this->assertEquals('body', $body->tagName);
-        $this->assertTrue($body->hasAttributes());
-        $this->assertEquals('a', $body->getAttribute('id'));
-        $this->assertEquals('b c', $body->getAttribute('class'));
+        $body = $root->getElementsByTagName('body')->item(0);
+        self::assertEquals('body', $body->tagName);
+        self::assertTrue($body->hasAttributes());
+        self::assertEquals('a', $body->getAttribute('id'));
+        self::assertEquals('b c', $body->getAttribute('class'));
+        self::assertEquals('ñø', $body->getAttribute('data-iñtërnâtiônàlizætiøn'));
 
         $body2 = $doc->getElementById('a');
-        $this->assertEquals('body', $body2->tagName);
-        $this->assertEquals('a', $body2->getAttribute('id'));
+        self::assertEquals('body', $body2->tagName);
+        self::assertEquals('a', $body2->getAttribute('id'));
     }
 
     public function testSVGAttributes()
@@ -291,13 +301,13 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $root = $doc->documentElement;
 
         $svg = $root->getElementsByTagName('svg')->item(0);
-        $this->assertTrue($svg->hasAttribute('viewBox'));
+        self::assertTrue($svg->hasAttribute('viewBox'));
 
         $rect = $root->getElementsByTagName('rect')->item(0);
-        $this->assertTrue($rect->hasAttribute('textLength'));
+        self::assertTrue($rect->hasAttribute('textLength'));
 
         $ac = $root->getElementsByTagName('animateColor');
-        $this->assertEquals(1, $ac->length);
+        self::assertEquals(1, $ac->length);
     }
 
     public function testMathMLAttribute()
@@ -319,7 +329,7 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $root = $doc->documentElement;
 
         $csymbol = $root->getElementsByTagName('csymbol')->item(0);
-        $this->assertTrue($csymbol->hasAttribute('definitionURL'));
+        self::assertTrue($csymbol->hasAttribute('definitionURL'));
     }
 
     public function testMissingHtmlTag()
@@ -327,8 +337,8 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $html = "<!DOCTYPE html><title>test</title>";
         $doc = $this->parse($html);
 
-        $this->assertEquals('html', $doc->documentElement->tagName);
-        $this->assertEquals('title', $doc->documentElement->childNodes->item(0)->tagName);
+        self::assertEquals('html', $doc->documentElement->tagName);
+        self::assertEquals('title', $doc->documentElement->childNodes->item(0)->tagName);
     }
 
     public function testComment()
@@ -338,19 +348,19 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $doc = $this->parse($html);
 
         $comment = $doc->documentElement->childNodes->item(0);
-        $this->assertEquals(XML_COMMENT_NODE, $comment->nodeType);
-        $this->assertEquals("Hello World.", $comment->data);
+        self::assertEquals(XML_COMMENT_NODE, $comment->nodeType);
+        self::assertEquals("Hello World.", $comment->data);
 
         $html = '<!--Hello World.--><html></html>';
         $doc = $this->parse($html);
 
         $comment = $doc->childNodes->item(1);
-        $this->assertEquals(XML_COMMENT_NODE, $comment->nodeType);
-        $this->assertEquals("Hello World.", $comment->data);
+        self::assertEquals(XML_COMMENT_NODE, $comment->nodeType);
+        self::assertEquals("Hello World.", $comment->data);
 
         $comment = $doc->childNodes->item(2);
-        $this->assertEquals(XML_ELEMENT_NODE, $comment->nodeType);
-        $this->assertEquals("html", $comment->tagName);
+        self::assertEquals(XML_ELEMENT_NODE, $comment->nodeType);
+        self::assertEquals("html", $comment->tagName);
     }
 
     public function testCDATA()
@@ -359,10 +369,10 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $doc = $this->parse($html);
 
         $wrapper = $doc->getElementsByTagName('math')->item(0);
-        $this->assertEquals(1, $wrapper->childNodes->length);
+        self::assertEquals(1, $wrapper->childNodes->length);
         $cdata = $wrapper->childNodes->item(0);
-        $this->assertEquals(XML_CDATA_SECTION_NODE, $cdata->nodeType);
-        $this->assertEquals('test', $cdata->data);
+        self::assertEquals(XML_CDATA_SECTION_NODE, $cdata->nodeType);
+        self::assertEquals('test', $cdata->data);
     }
 
     public function testText()
@@ -371,18 +381,18 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $doc = $this->parse($html);
 
         $wrapper = $doc->getElementsByTagName('math')->item(0);
-        $this->assertEquals(1, $wrapper->childNodes->length);
+        self::assertEquals(1, $wrapper->childNodes->length);
         $data = $wrapper->childNodes->item(0);
-        $this->assertEquals(XML_TEXT_NODE, $data->nodeType);
-        $this->assertEquals('test', $data->data);
+        self::assertEquals(XML_TEXT_NODE, $data->nodeType);
+        self::assertEquals('test', $data->data);
 
         // The DomTreeBuilder has special handling for text when in before head mode.
         $html = "<!DOCTYPE html><html>
     Foo<head></head><body></body></html>";
         $doc = $this->parse($html);
-        $this->assertEquals('Line 0, Col 0: Unexpected text. Ignoring: Foo', $this->errors[0]);
+        self::assertEquals('Line 0, Col 0: Unexpected text. Ignoring: Foo', $this->errors[0]);
         $headElement = $doc->documentElement->firstChild;
-        $this->assertEquals('head', $headElement->tagName);
+        self::assertEquals('head', $headElement->tagName);
     }
 
     public function testParseErrors()
@@ -392,26 +402,26 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
 
         // We're JUST testing that we can access errors. Actual testing of
         // error messages happen in the Tokenizer's tests.
-        $this->assertGreaterThan(0, count($this->errors));
-        $this->assertTrue(is_string($this->errors[0]));
+        self::assertGreaterThan(0, count($this->errors));
+        self::assertTrue(is_string($this->errors[0]));
     }
 
     public function testProcessingInstruction()
     {
         // Test the simple case, which is where PIs are inserted into the DOM.
         $doc = $this->parse('<!DOCTYPE html><html><?foo bar?>');
-        $this->assertEquals(1, $doc->documentElement->childNodes->length);
+        self::assertEquals(1, $doc->documentElement->childNodes->length);
         $pi = $doc->documentElement->firstChild;
-        $this->assertInstanceOf('\DOMProcessingInstruction', $pi);
-        $this->assertEquals('foo', $pi->nodeName);
-        $this->assertEquals('bar', $pi->data);
+        self::assertInstanceOf('\DOMProcessingInstruction', $pi);
+        self::assertEquals('foo', $pi->nodeName);
+        self::assertEquals('bar', $pi->data);
 
         // Leading xml PIs should be ignored.
         $doc = $this->parse('<?xml version="1.0"?><!DOCTYPE html><html><head></head></html>');
 
-        $this->assertEquals(2, $doc->childNodes->length);
-        $this->assertInstanceOf('\DOMDocumentType', $doc->childNodes->item(0));
-        $this->assertInstanceOf('\DOMElement', $doc->childNodes->item(1));
+        self::assertEquals(2, $doc->childNodes->length);
+        self::assertInstanceOf('\DOMDocumentType', $doc->childNodes->item(0));
+        self::assertInstanceOf('\DOMElement', $doc->childNodes->item(1));
     }
 
     public function testAutocloseP()
@@ -420,8 +430,8 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $doc = $this->parse($html);
 
         $p = $doc->getElementsByTagName('p')->item(0);
-        $this->assertEquals(0, $p->childNodes->length);
-        $this->assertEquals('figure', $p->nextSibling->tagName);
+        self::assertEquals(0, $p->childNodes->length);
+        self::assertEquals('figure', $p->nextSibling->tagName);
     }
 
     public function testAutocloseLI()
@@ -435,7 +445,7 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
 
         $doc = $this->parse($html);
         $length = $doc->getElementsByTagName('ul')->item(0)->childNodes->length;
-        $this->assertEquals(3, $length);
+        self::assertEquals(3, $length);
     }
 
     public function testMathML()
@@ -455,10 +465,10 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
 
         $doc = $this->parse($html);
         $math = $doc->getElementsByTagName('math')->item(0);
-        $this->assertEquals('math', $math->tagName);
-        $this->assertEquals('math', $math->nodeName);
-        $this->assertEquals('math', $math->localName);
-        $this->assertEquals('http://www.w3.org/1998/Math/MathML', $math->namespaceURI);
+        self::assertEquals('math', $math->tagName);
+        self::assertEquals('math', $math->nodeName);
+        self::assertEquals('math', $math->localName);
+        self::assertEquals('http://www.w3.org/1998/Math/MathML', $math->namespaceURI);
     }
 
     public function testSVG()
@@ -479,28 +489,28 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
 
         $doc = $this->parse($html);
         $svg = $doc->getElementsByTagName('svg')->item(0);
-        $this->assertEquals('svg', $svg->tagName);
-        $this->assertEquals('svg', $svg->nodeName);
-        $this->assertEquals('svg', $svg->localName);
-        $this->assertEquals('http://www.w3.org/2000/svg', $svg->namespaceURI);
+        self::assertEquals('svg', $svg->tagName);
+        self::assertEquals('svg', $svg->nodeName);
+        self::assertEquals('svg', $svg->localName);
+        self::assertEquals('http://www.w3.org/2000/svg', $svg->namespaceURI);
 
         $textPath = $doc->getElementsByTagName('textPath')->item(0);
-        $this->assertEquals('textPath', $textPath->tagName);
+        self::assertEquals('textPath', $textPath->tagName);
     }
 
     public function testNoScript()
     {
         $html = '<!DOCTYPE html><html><head><noscript>No JS</noscript></head></html>';
         $doc = $this->parse($html);
-        $this->assertEmpty($this->errors);
+        self::assertEmpty($this->errors);
         $noscript = $doc->getElementsByTagName('noscript')->item(0);
-        $this->assertEquals('noscript', $noscript->tagName);
+        self::assertEquals('noscript', $noscript->tagName);
 
         $html = '<!DOCTYPE html><html><body><noscript><p>No JS</p></noscript></body></html>';
         $doc = $this->parse($html);
-        $this->assertEmpty($this->errors);
+        self::assertEmpty($this->errors);
         $p = $doc->getElementsByTagName('p')->item(0);
-        $this->assertEquals('p', $p->tagName);
+        self::assertEquals('p', $p->tagName);
     }
 
     /**
@@ -512,10 +522,10 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $doc = $this->parse($html);
         $span = $doc->getElementById('test');
 
-        $this->assertEmpty($this->errors);
+        self::assertEmpty($this->errors);
 
-        $this->assertEquals('span', $span->tagName);
-        $this->assertEquals('Test', $span->textContent);
+        self::assertEquals('span', $span->tagName);
+        self::assertEquals('Test', $span->textContent);
     }
 
     public function testInstructionProcessor()
@@ -534,11 +544,11 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $dom = $treeBuilder->document();
         $div = $dom->getElementsByTagName('div')->item(0);
 
-        $this->assertEquals(1, $is->count);
-        $this->assertEquals('foo', $is->name);
-        $this->assertEquals('bar ', $is->data);
-        $this->assertEquals('div', $div->tagName);
-        $this->assertEquals('foo', $div->textContent);
+        self::assertEquals(1, $is->count);
+        self::assertEquals('foo', $is->name);
+        self::assertEquals('bar ', $is->data);
+        self::assertEquals('div', $div->tagName);
+        self::assertEquals('foo', $div->textContent);
     }
 
     public function testSelectGroupedOptions()
@@ -564,9 +574,9 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
     </body>
 </html>
 EOM;
-        $dom  = $this->parse($html);
+        $dom = $this->parse($html);
 
-        $this->assertSame(3, $dom->getElementById('first')->getElementsByTagName('option')->length);
-        $this->assertSame(2, $dom->getElementById('second')->getElementsByTagName('option')->length);
+        self::assertSame(3, $dom->getElementById('first')->getElementsByTagName('option')->length);
+        self::assertSame(2, $dom->getElementById('second')->getElementsByTagName('option')->length);
     }
 }

--- a/test/HTML5/Parser/EventStack.php
+++ b/test/HTML5/Parser/EventStack.php
@@ -16,7 +16,9 @@ use Masterminds\HTML5\Parser\EventHandler;
  */
 class EventStack implements EventHandler
 {
-
+    /**
+     * @var array
+     */
     protected $stack;
 
     public function __construct()
@@ -37,11 +39,19 @@ class EventStack implements EventHandler
         return count($this->stack);
     }
 
+    /**
+     * @param $index
+     * @return mixed
+     */
     public function get($index)
     {
         return $this->stack[$index];
     }
 
+    /**
+     * @param $event
+     * @param null $data
+     */
     protected function store($event, $data = null)
     {
         $this->stack[] = array(
@@ -50,6 +60,12 @@ class EventStack implements EventHandler
         );
     }
 
+    /**
+     * @param string $name
+     * @param int $type
+     * @param null $id
+     * @param bool $quirks
+     */
     public function doctype($name, $type = 0, $id = null, $quirks = false)
     {
         $args = array(
@@ -61,15 +77,25 @@ class EventStack implements EventHandler
         $this->store('doctype', $args);
     }
 
+    /**
+     * @param string $name
+     * @param array $attributes
+     * @param bool $selfClosing
+     *
+     * @return int
+     */
     public function startTag($name, $attributes = array(), $selfClosing = false)
     {
         $args = func_get_args();
         $this->store('startTag', $args);
-        if ($name == 'pre' || $name == 'script') {
+        if ($name === 'pre' || $name === 'script') {
             return Elements::TEXT_RAW;
         }
     }
 
+    /**
+     * @param $name
+     */
     public function endTag($name)
     {
         $this->store('endTag', array(
@@ -77,6 +103,9 @@ class EventStack implements EventHandler
         ));
     }
 
+    /**
+     * @param $cdata
+     */
     public function comment($cdata)
     {
         $this->store('comment', array(
@@ -84,11 +113,17 @@ class EventStack implements EventHandler
         ));
     }
 
+    /**
+     * @param string $data
+     */
     public function cdata($data)
     {
         $this->store('cdata', func_get_args());
     }
 
+    /**
+     * @param $cdata
+     */
     public function text($cdata)
     {
         // fprintf(STDOUT, "Received TEXT event with: " . $cdata);
@@ -102,6 +137,11 @@ class EventStack implements EventHandler
         $this->store('eof');
     }
 
+    /**
+     * @param $msg
+     * @param $line
+     * @param $col
+     */
     public function parseError($msg, $line, $col)
     {
         // throw new EventStackParseError(sprintf("%s (line %d, col %d)", $msg, $line, $col));
@@ -109,6 +149,10 @@ class EventStack implements EventHandler
         $this->store('error', func_get_args());
     }
 
+    /**
+     * @param string $name
+     * @param null $data
+     */
     public function processingInstruction($name, $data = null)
     {
         $this->store('pi', func_get_args());

--- a/test/HTML5/Parser/FileInputStreamTest.php
+++ b/test/HTML5/Parser/FileInputStreamTest.php
@@ -10,7 +10,7 @@ class FileInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
     {
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
 
-        $this->assertInstanceOf('\Masterminds\HTML5\Parser\FileInputStream', $s);
+        self::assertInstanceOf('\Masterminds\HTML5\Parser\FileInputStream', $s);
     }
 
     public function testNext()
@@ -18,54 +18,54 @@ class FileInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
 
         $s->next();
-        $this->assertEquals('!', $s->current());
+        self::assertEquals('!', $s->current());
         $s->next();
-        $this->assertEquals('d', $s->current());
+        self::assertEquals('d', $s->current());
     }
 
     public function testKey()
     {
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
 
-        $this->assertEquals(0, $s->key());
+        self::assertEquals(0, $s->key());
 
         $s->next();
-        $this->assertEquals(1, $s->key());
+        self::assertEquals(1, $s->key());
     }
 
     public function testPeek()
     {
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
 
-        $this->assertEquals('!', $s->peek());
+        self::assertEquals('!', $s->peek());
 
         $s->next();
-        $this->assertEquals('d', $s->peek());
+        self::assertEquals('d', $s->peek());
     }
 
     public function testCurrent()
     {
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
 
-        $this->assertEquals('<', $s->current());
+        self::assertEquals('<', $s->current());
 
         $s->next();
-        $this->assertEquals('!', $s->current());
+        self::assertEquals('!', $s->current());
 
         $s->next();
-        $this->assertEquals('d', $s->current());
+        self::assertEquals('d', $s->current());
     }
 
     public function testColumnOffset()
     {
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
-        $this->assertEquals(0, $s->columnOffset());
+        self::assertEquals(0, $s->columnOffset());
         $s->next();
-        $this->assertEquals(1, $s->columnOffset());
+        self::assertEquals(1, $s->columnOffset());
         $s->next();
-        $this->assertEquals(2, $s->columnOffset());
+        self::assertEquals(2, $s->columnOffset());
         $s->next();
-        $this->assertEquals(3, $s->columnOffset());
+        self::assertEquals(3, $s->columnOffset());
 
         // Make sure we get to the second line
         $s->next();
@@ -81,19 +81,19 @@ class FileInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
         $s->next();
         $s->next();
         $s->next();
-        $this->assertEquals(0, $s->columnOffset());
+        self::assertEquals(0, $s->columnOffset());
 
         $s->next();
         $canary = $s->current(); // h
-        $this->assertEquals('h', $canary);
-        $this->assertEquals(1, $s->columnOffset());
+        self::assertEquals('h', $canary);
+        self::assertEquals(1, $s->columnOffset());
     }
 
     public function testCurrentLine()
     {
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
 
-        $this->assertEquals(1, $s->currentLine());
+        self::assertEquals(1, $s->currentLine());
 
         // Make sure we get to the second line
         $s->next();
@@ -112,7 +112,7 @@ class FileInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
         $s->next();
         $s->next();
         $s->next();
-        $this->assertEquals(2, $s->currentLine());
+        self::assertEquals(2, $s->currentLine());
 
         // Make sure we get to the third line
         $s->next();
@@ -132,44 +132,50 @@ class FileInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
         $s->next();
         $s->next();
         $s->next();
-        $this->assertEquals(3, $s->currentLine());
+        self::assertEquals(3, $s->currentLine());
     }
 
     public function testRemainingChars()
     {
         $text = file_get_contents(__DIR__ . '/FileInputStreamTest.html');
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
-        $this->assertEquals($text, $s->remainingChars());
+        self::assertEquals(
+            str_replace(array("\n", "\r", "\r\n"), "", $text),
+            str_replace(array("\n", "\r", "\r\n"), "", $s->remainingChars())
+        );
 
         $text = substr(file_get_contents(__DIR__ . '/FileInputStreamTest.html'), 1);
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
         $s->next(); // Pop one.
-        $this->assertEquals($text, $s->remainingChars());
+        self::assertEquals(
+            str_replace(array("\n", "\r", "\r\n"), "", $text),
+            str_replace(array("\n", "\r", "\r\n"), "", $s->remainingChars())
+        );
     }
 
     public function testCharsUnitl()
     {
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
 
-        $this->assertEquals('', $s->charsUntil('<'));
+        self::assertEquals('', $s->charsUntil('<'));
         // Pointer at '<', moves to ' '
-        $this->assertEquals('<!doctype', $s->charsUntil(' ', 20));
+        self::assertEquals('<!doctype', $s->charsUntil(' ', 20));
 
         // Pointer at ' ', moves to '>'
-        $this->assertEquals(' html', $s->charsUntil('>'));
+        self::assertEquals(' html', $s->charsUntil('>'));
 
         // Pointer at '>', moves to '\n'.
-        $this->assertEquals('>', $s->charsUntil("\n"));
+        self::assertEquals('>', $s->charsUntil("\n"));
 
         // Pointer at '\n', move forward then to the next'\n'.
         $s->next();
-        $this->assertEquals('<html lang="en">', $s->charsUntil("\n"));
+        self::assertEquals('<html lang="en">', $s->charsUntil("\n"));
 
         // Ony get one of the spaces.
-        $this->assertEquals("\n ", $s->charsUntil('<', 2));
+        self::assertEquals("\n ", $s->charsUntil('<', 2));
 
         // Get the other space.
-        $this->assertEquals(" ", $s->charsUntil('<'));
+        self::assertEquals(" ", $s->charsUntil('<'));
 
         // This should scan to the end of the file.
         $text = "<head>
@@ -180,16 +186,19 @@ class FileInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
     <p>This is a test.</p>
   </body>
 </html>";
-        $this->assertEquals($text, $s->charsUntil("\t"));
+        self::assertEquals(
+            str_replace(array("\n", "\r", "\r\n"), "", $text),
+            str_replace(array("\n", "\r", "\r\n"), "", $s->charsUntil("\t"))
+        );
     }
 
     public function testCharsWhile()
     {
         $s = new FileInputStream(__DIR__ . '/FileInputStreamTest.html');
 
-        $this->assertEquals('<!', $s->charsWhile('!<'));
-        $this->assertEquals('', $s->charsWhile('>'));
-        $this->assertEquals('doctype', $s->charsWhile('odcyept'));
-        $this->assertEquals(' htm', $s->charsWhile('html ', 4));
+        self::assertEquals('<!', $s->charsWhile('!<'));
+        self::assertEquals('', $s->charsWhile('>'));
+        self::assertEquals('doctype', $s->charsWhile('odcyept'));
+        self::assertEquals(' htm', $s->charsWhile('html ', 4));
     }
 }

--- a/test/HTML5/Parser/InstructionProcessorMock.php
+++ b/test/HTML5/Parser/InstructionProcessorMock.php
@@ -14,7 +14,7 @@ class InstructionProcessorMock implements \Masterminds\HTML5\InstructionProcesso
     {
         $this->name = $name;
         $this->data = $data;
-        $this->count ++;
+        $this->count++;
 
         $div = $element->ownerDocument->createElement("div");
         $div->nodeValue = 'foo';

--- a/test/HTML5/Parser/ScannerTest.php
+++ b/test/HTML5/Parser/ScannerTest.php
@@ -19,35 +19,35 @@ class ScannerTest extends \Masterminds\HTML5\Tests\TestCase
         $is = new StringInputStream("abc");
         $s = new Scanner($is);
 
-        $this->assertInstanceOf('\Masterminds\HTML5\Parser\Scanner', $s);
+        static::assertInstanceOf('\Masterminds\HTML5\Parser\Scanner', $s);
     }
 
     public function testNext()
     {
         $s = new Scanner(new StringInputStream("abc"));
 
-        $this->assertEquals('b', $s->next());
-        $this->assertEquals('c', $s->next());
+        self::assertEquals('b', $s->next());
+        self::assertEquals('c', $s->next());
     }
 
     public function testPosition()
     {
         $s = new Scanner(new StringInputStream("abc"));
 
-        $this->assertEquals(0, $s->position());
+        self::assertEquals(0, $s->position());
 
         $s->next();
-        $this->assertEquals(1, $s->position());
+        self::assertEquals(1, $s->position());
     }
 
     public function testPeek()
     {
         $s = new Scanner(new StringInputStream("abc"));
 
-        $this->assertEquals('b', $s->peek());
+        self::assertEquals('b', $s->peek());
 
         $s->next();
-        $this->assertEquals('c', $s->peek());
+        self::assertEquals('c', $s->peek());
     }
 
     public function testCurrent()
@@ -55,14 +55,14 @@ class ScannerTest extends \Masterminds\HTML5\Tests\TestCase
         $s = new Scanner(new StringInputStream("abc"));
 
         // Before scanning the string begins the current is empty.
-        $this->assertEquals('a', $s->current());
+        self::assertEquals('a', $s->current());
 
         $c = $s->next();
-        $this->assertEquals('b', $s->current());
+        self::assertEquals('b', $s->current());
 
         // Test movement through the string.
         $c = $s->next();
-        $this->assertEquals('c', $s->current());
+        self::assertEquals('c', $s->current());
     }
 
     public function testUnconsume()
@@ -75,71 +75,71 @@ class ScannerTest extends \Masterminds\HTML5\Tests\TestCase
 
         // Move forward a bunch of positions.
         $amount = 7;
-        for ($i = 0; $i < $amount; $i ++) {
+        for ($i = 0; $i < $amount; $i++) {
             $s->next();
         }
 
         // Roll back the amount we moved forward.
         $s->unconsume($amount);
 
-        $this->assertEquals($start, $s->position());
+        self::assertEquals($start, $s->position());
     }
 
     public function testGetHex()
     {
         $s = new Scanner(new StringInputStream("ab13ck45DE*"));
 
-        $this->assertEquals('ab13c', $s->getHex());
+        self::assertEquals('ab13c', $s->getHex());
 
         $s->next();
-        $this->assertEquals('45DE', $s->getHex());
+        self::assertEquals('45DE', $s->getHex());
     }
 
     public function testGetAsciiAlpha()
     {
         $s = new Scanner(new StringInputStream("abcdef1%mnop*"));
 
-        $this->assertEquals('abcdef', $s->getAsciiAlpha());
+        self::assertEquals('abcdef', $s->getAsciiAlpha());
 
         // Move past the 1% to scan the next group of text.
         $s->next();
         $s->next();
-        $this->assertEquals('mnop', $s->getAsciiAlpha());
+        self::assertEquals('mnop', $s->getAsciiAlpha());
     }
 
     public function testGetAsciiAlphaNum()
     {
         $s = new Scanner(new StringInputStream("abcdef1ghpo#mn94op"));
 
-        $this->assertEquals('abcdef1ghpo', $s->getAsciiAlphaNum());
+        self::assertEquals('abcdef1ghpo', $s->getAsciiAlphaNum());
 
         // Move past the # to scan the next group of text.
         $s->next();
-        $this->assertEquals('mn94op', $s->getAsciiAlphaNum());
+        self::assertEquals('mn94op', $s->getAsciiAlphaNum());
     }
 
     public function testGetNumeric()
     {
         $s = new Scanner(new StringInputStream("1784a 45 9867 #"));
 
-        $this->assertEquals('1784', $s->getNumeric());
+        self::assertEquals('1784', $s->getNumeric());
 
         // Move past the 'a ' to scan the next group of text.
         $s->next();
         $s->next();
-        $this->assertEquals('45', $s->getNumeric());
+        self::assertEquals('45', $s->getNumeric());
     }
 
     public function testCurrentLine()
     {
         $s = new Scanner(new StringInputStream("1784a\n45\n9867 #\nThis is a test."));
 
-        $this->assertEquals(1, $s->currentLine());
+        self::assertEquals(1, $s->currentLine());
 
         // Move to the next line.
         $s->getAsciiAlphaNum();
         $s->next();
-        $this->assertEquals(2, $s->currentLine());
+        self::assertEquals(2, $s->currentLine());
     }
 
     public function testColumnOffset()
@@ -148,7 +148,7 @@ class ScannerTest extends \Masterminds\HTML5\Tests\TestCase
 
         // Move the pointer to the space.
         $s->getAsciiAlphaNum();
-        $this->assertEquals(5, $s->columnOffset());
+        self::assertEquals(5, $s->columnOffset());
 
         // We move the pointer ahead. There must be a better way to do this.
         $s->next();
@@ -157,7 +157,7 @@ class ScannerTest extends \Masterminds\HTML5\Tests\TestCase
         $s->next();
         $s->next();
         $s->next();
-        $this->assertEquals(3, $s->columnOffset());
+        self::assertEquals(3, $s->columnOffset());
     }
 
     public function testRemainingChars()
@@ -166,6 +166,6 @@ class ScannerTest extends \Masterminds\HTML5\Tests\TestCase
         $s = new Scanner(new StringInputStream("1784a\n45\n9867 #\nThis is a test."));
 
         $s->getAsciiAlphaNum();
-        $this->assertEquals($string, $s->remainingChars());
+        self::assertEquals($string, $s->remainingChars());
     }
 }

--- a/test/HTML5/Parser/StringInputStreamTest.php
+++ b/test/HTML5/Parser/StringInputStreamTest.php
@@ -13,7 +13,7 @@ class StringInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
     {
         $s = new StringInputStream("abc");
 
-        $this->assertInstanceOf('\Masterminds\HTML5\Parser\StringInputStream', $s);
+        self::assertInstanceOf('\Masterminds\HTML5\Parser\StringInputStream', $s);
     }
 
     public function testNext()
@@ -21,29 +21,29 @@ class StringInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
         $s = new StringInputStream("abc");
 
         $s->next();
-        $this->assertEquals('b', $s->current());
+        self::assertEquals('b', $s->current());
         $s->next();
-        $this->assertEquals('c', $s->current());
+        self::assertEquals('c', $s->current());
     }
 
     public function testKey()
     {
         $s = new StringInputStream("abc");
 
-        $this->assertEquals(0, $s->key());
+        self::assertEquals(0, $s->key());
 
         $s->next();
-        $this->assertEquals(1, $s->key());
+        self::assertEquals(1, $s->key());
     }
 
     public function testPeek()
     {
         $s = new StringInputStream("abc");
 
-        $this->assertEquals('b', $s->peek());
+        self::assertEquals('b', $s->peek());
 
         $s->next();
-        $this->assertEquals('c', $s->peek());
+        self::assertEquals('c', $s->peek());
     }
 
     public function testCurrent()
@@ -51,53 +51,53 @@ class StringInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
         $s = new StringInputStream("abc");
 
         // Before scanning the string begins the current is empty.
-        $this->assertEquals('a', $s->current());
+        self::assertEquals('a', $s->current());
 
         $s->next();
-        $this->assertEquals('b', $s->current());
+        self::assertEquals('b', $s->current());
 
         // Test movement through the string.
         $s->next();
-        $this->assertEquals('c', $s->current());
+        self::assertEquals('c', $s->current());
     }
 
     public function testColumnOffset()
     {
         $s = new StringInputStream("abc\ndef\n");
-        $this->assertEquals(0, $s->columnOffset());
+        self::assertEquals(0, $s->columnOffset());
         $s->next();
-        $this->assertEquals(1, $s->columnOffset());
+        self::assertEquals(1, $s->columnOffset());
         $s->next();
-        $this->assertEquals(2, $s->columnOffset());
+        self::assertEquals(2, $s->columnOffset());
         $s->next();
-        $this->assertEquals(3, $s->columnOffset());
+        self::assertEquals(3, $s->columnOffset());
         $s->next(); // LF
-        $this->assertEquals(0, $s->columnOffset());
+        self::assertEquals(0, $s->columnOffset());
         $s->next();
         $canary = $s->current(); // e
-        $this->assertEquals('e', $canary);
-        $this->assertEquals(1, $s->columnOffset());
+        self::assertEquals('e', $canary);
+        self::assertEquals(1, $s->columnOffset());
 
         $s = new StringInputStream("abc");
-        $this->assertEquals(0, $s->columnOffset());
+        self::assertEquals(0, $s->columnOffset());
         $s->next();
-        $this->assertEquals(1, $s->columnOffset());
+        self::assertEquals(1, $s->columnOffset());
         $s->next();
-        $this->assertEquals(2, $s->columnOffset());
+        self::assertEquals(2, $s->columnOffset());
     }
 
     public function testCurrentLine()
     {
         $txt = "1\n2\n\n\n\n3";
         $stream = new StringInputStream($txt);
-        $this->assertEquals(1, $stream->currentLine());
+        self::assertEquals(1, $stream->currentLine());
 
         // Advance over 1 and LF on to line 2 value 2.
         $stream->next();
         $stream->next();
         $canary = $stream->current();
-        $this->assertEquals(2, $stream->currentLine());
-        $this->assertEquals('2', $canary);
+        self::assertEquals(2, $stream->currentLine());
+        self::assertEquals('2', $canary);
 
         // Advance over 4x LF
         $stream->next();
@@ -105,44 +105,44 @@ class StringInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
         $stream->next();
         $stream->next();
         $stream->next();
-        $this->assertEquals(6, $stream->currentLine());
-        $this->assertEquals('3', $stream->current());
+        self::assertEquals(6, $stream->currentLine());
+        self::assertEquals('3', $stream->current());
 
         // Make sure it doesn't do 7.
-        $this->assertEquals(6, $stream->currentLine());
+        self::assertEquals(6, $stream->currentLine());
     }
 
     public function testRemainingChars()
     {
         $text = "abcd";
         $s = new StringInputStream($text);
-        $this->assertEquals($text, $s->remainingChars());
+        self::assertEquals($text, $s->remainingChars());
 
         $text = "abcd";
         $s = new StringInputStream($text);
         $s->next(); // Pop one.
-        $this->assertEquals('bcd', $s->remainingChars());
+        self::assertEquals('bcd', $s->remainingChars());
     }
 
     public function testCharsUnitl()
     {
         $text = "abcdefffffffghi";
         $s = new StringInputStream($text);
-        $this->assertEquals('', $s->charsUntil('a'));
+        self::assertEquals('', $s->charsUntil('a'));
         // Pointer at 'a', moves 2 to 'c'
-        $this->assertEquals('ab', $s->charsUntil('w', 2));
+        self::assertEquals('ab', $s->charsUntil('w', 2));
 
         // Pointer at 'c', moves to first 'f'
-        $this->assertEquals('cde', $s->charsUntil('fzxv'));
+        self::assertEquals('cde', $s->charsUntil('fzxv'));
 
         // Only get five 'f's
-        $this->assertEquals('fffff', $s->charsUntil('g', 5));
+        self::assertEquals('fffff', $s->charsUntil('g', 5));
 
         // Get just the last two 'f's
-        $this->assertEquals('ff', $s->charsUntil('g'));
+        self::assertEquals('ff', $s->charsUntil('g'));
 
         // This should scan to the end.
-        $this->assertEquals('ghi', $s->charsUntil('w', 9));
+        self::assertEquals('ghi', $s->charsUntil('w', 9));
     }
 
     public function testCharsWhile()
@@ -150,178 +150,148 @@ class StringInputStreamTest extends \Masterminds\HTML5\Tests\TestCase
         $text = "abcdefffffffghi";
         $s = new StringInputStream($text);
 
-        $this->assertEquals('ab', $s->charsWhile('ba'));
+        self::assertEquals('ab', $s->charsWhile('ba'));
 
-        $this->assertEquals('', $s->charsWhile('a'));
-        $this->assertEquals('cde', $s->charsWhile('cdeba'));
-        $this->assertEquals('ff', $s->charsWhile('f', 2));
-        $this->assertEquals('fffff', $s->charsWhile('f'));
-        $this->assertEquals('g', $s->charsWhile('fg'));
-        $this->assertEquals('hi', $s->charsWhile('fghi', 99));
+        self::assertEquals('', $s->charsWhile('a'));
+        self::assertEquals('cde', $s->charsWhile('cdeba'));
+        self::assertEquals('ff', $s->charsWhile('f', 2));
+        self::assertEquals('fffff', $s->charsWhile('f'));
+        self::assertEquals('g', $s->charsWhile('fg'));
+        self::assertEquals('hi', $s->charsWhile('fghi', 99));
     }
 
     public function testBOM()
     {
         // Ignore in-text BOM.
         $stream = new StringInputStream("a\xEF\xBB\xBF");
-        $this->assertEquals("a\xEF\xBB\xBF", $stream->remainingChars(), 'A non-leading U+FEFF (BOM/ZWNBSP) should remain');
+        self::assertEquals("a\xEF\xBB\xBF", $stream->remainingChars(), 'A non-leading U+FEFF (BOM/ZWNBSP) should remain');
 
         // Strip leading BOM
         $leading = new StringInputStream("\xEF\xBB\xBFa");
-        $this->assertEquals('a', $leading->current(), 'BOM should be stripped');
+        self::assertEquals('a', $leading->current(), 'BOM should be stripped');
     }
 
     public function testCarriageReturn()
     {
         // Replace NULL with Unicode replacement.
         $stream = new StringInputStream("\0\0\0");
-        $this->assertEquals("\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", $stream->remainingChars(), 'Null character should be replaced by U+FFFD');
-        $this->assertEquals(3, count($stream->errors), 'Null character should set parse error: ' . print_r($stream->errors, true));
+        self::assertEquals("", $stream->remainingChars(), 'Null character should be replaced by U+FFFD');
+        self::assertEquals(0, count($stream->errors), 'Null character should set parse error: ' . print_r($stream->errors, true));
 
         // Remove CR when next to LF.
         $stream = new StringInputStream("\r\n");
-        $this->assertEquals("\n", $stream->remainingChars(), 'CRLF should be replaced by LF');
+        self::assertEquals("\n", $stream->remainingChars(), 'CRLF should be replaced by LF');
 
         // Convert CR to LF when on its own.
         $stream = new StringInputStream("\r");
-        $this->assertEquals("\n", $stream->remainingChars(), 'CR should be replaced by LF');
+        self::assertEquals("\n", $stream->remainingChars(), 'CR should be replaced by LF');
     }
 
-    public function invalidParseErrorTestHandler($input, $numErrors, $name)
+    public function invalidParseErrorTestHandler($input, $numErrors, $name, $value = '')
     {
         $stream = new StringInputStream($input, 'UTF-8');
-        $this->assertEquals($input, $stream->remainingChars(), $name . ' (stream content)');
-        $this->assertEquals($numErrors, count($stream->errors), $name . ' (number of errors)');
-    }
-
-    public function testInvalidReplace()
-    {
-        $invalidTest = array(
-
-            // Min/max overlong
-            "\xC0\x80a" => 'Overlong representation of U+0000',
-            "\xE0\x80\x80a" => 'Overlong representation of U+0000',
-            "\xF0\x80\x80\x80a" => 'Overlong representation of U+0000',
-            "\xF8\x80\x80\x80\x80a" => 'Overlong representation of U+0000',
-            "\xFC\x80\x80\x80\x80\x80a" => 'Overlong representation of U+0000',
-            "\xC1\xBFa" => 'Overlong representation of U+007F',
-            "\xE0\x9F\xBFa" => 'Overlong representation of U+07FF',
-            "\xF0\x8F\xBF\xBFa" => 'Overlong representation of U+FFFF',
-
-            "a\xDF" => 'Incomplete two byte sequence (missing final byte)',
-            "a\xEF\xBF" => 'Incomplete three byte sequence (missing final byte)',
-            "a\xF4\xBF\xBF" => 'Incomplete four byte sequence (missing final byte)',
-
-            // Min/max continuation bytes
-            "a\x80" => 'Lone 80 continuation byte',
-            "a\xBF" => 'Lone BF continuation byte',
-
-            // Invalid bytes (these can never occur)
-            "a\xFE" => 'Invalid FE byte',
-            "a\xFF" => 'Invalid FF byte'
-        );
-        foreach ($invalidTest as $test => $note) {
-            $stream = new StringInputStream($test);
-            $this->assertEquals('a', $stream->remainingChars(), $note);
-        }
-
-        // MPB:
-        // It appears that iconv just leaves these alone. Not sure what to
-        // do.
-        /*
-         * $converted = array( "a\xF5\x90\x80\x80" => 'U+110000, off unicode planes.', ); foreach ($converted as $test => $note) { $stream = new StringInputStream($test); $this->assertEquals(2, mb_strlen($stream->remainingChars()), $note); }
-         */
+        self::assertEquals($value, $stream->remainingChars(), $name . ' (stream content)');
+        self::assertEquals($numErrors, count($stream->errors), $name . ' (number of errors)');
     }
 
     public function testInvalidParseError()
     {
         // C0 controls (except U+0000 and U+000D due to different handling)
-        $this->invalidParseErrorTestHandler("\x01", 1, 'U+0001 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x02", 1, 'U+0002 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x03", 1, 'U+0003 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x04", 1, 'U+0004 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x05", 1, 'U+0005 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x06", 1, 'U+0006 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x07", 1, 'U+0007 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x08", 1, 'U+0008 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x09", 0, 'U+0009 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x0A", 0, 'U+000A (C0 control)');
-        $this->invalidParseErrorTestHandler("\x0B", 1, 'U+000B (C0 control)');
+        $this->invalidParseErrorTestHandler("\x01", 0, 'U+0001 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x02", 0, 'U+0002 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x03", 0, 'U+0003 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x04", 0, 'U+0004 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x05", 0, 'U+0005 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x06", 0, 'U+0006 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x07", 0, 'U+0007 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x08", 0, 'U+0008 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x09", 0, 'U+0009 (C0 control)', "	"); // space
+        $this->invalidParseErrorTestHandler("\x0A", 0, 'U+000A (C0 control)', "\x0A"); // line-break
+        $this->invalidParseErrorTestHandler("\x0B", 0, 'U+000B (C0 control)');
         $this->invalidParseErrorTestHandler("\x0C", 0, 'U+000C (C0 control)');
-        $this->invalidParseErrorTestHandler("\x0E", 1, 'U+000E (C0 control)');
-        $this->invalidParseErrorTestHandler("\x0F", 1, 'U+000F (C0 control)');
-        $this->invalidParseErrorTestHandler("\x10", 1, 'U+0010 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x11", 1, 'U+0011 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x12", 1, 'U+0012 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x13", 1, 'U+0013 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x14", 1, 'U+0014 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x15", 1, 'U+0015 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x16", 1, 'U+0016 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x17", 1, 'U+0017 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x18", 1, 'U+0018 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x19", 1, 'U+0019 (C0 control)');
-        $this->invalidParseErrorTestHandler("\x1A", 1, 'U+001A (C0 control)');
-        $this->invalidParseErrorTestHandler("\x1B", 1, 'U+001B (C0 control)');
-        $this->invalidParseErrorTestHandler("\x1C", 1, 'U+001C (C0 control)');
-        $this->invalidParseErrorTestHandler("\x1D", 1, 'U+001D (C0 control)');
-        $this->invalidParseErrorTestHandler("\x1E", 1, 'U+001E (C0 control)');
-        $this->invalidParseErrorTestHandler("\x1F", 1, 'U+001F (C0 control)');
+        $this->invalidParseErrorTestHandler("\x0E", 0, 'U+000E (C0 control)');
+        $this->invalidParseErrorTestHandler("\x0F", 0, 'U+000F (C0 control)');
+        $this->invalidParseErrorTestHandler("\x10", 0, 'U+0010 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x11", 0, 'U+0011 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x12", 0, 'U+0012 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x13", 0, 'U+0013 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x14", 0, 'U+0014 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x15", 0, 'U+0015 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x16", 0, 'U+0016 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x17", 0, 'U+0017 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x18", 0, 'U+0018 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x19", 0, 'U+0019 (C0 control)');
+        $this->invalidParseErrorTestHandler("\x1A", 0, 'U+001A (C0 control)');
+        $this->invalidParseErrorTestHandler("\x1B", 0, 'U+001B (C0 control)');
+        $this->invalidParseErrorTestHandler("\x1C", 0, 'U+001C (C0 control)');
+        $this->invalidParseErrorTestHandler("\x1D", 0, 'U+001D (C0 control)');
+        $this->invalidParseErrorTestHandler("\x1E", 0, 'U+001E (C0 control)');
+        $this->invalidParseErrorTestHandler("\x1F", 0, 'U+001F (C0 control)');
 
         // DEL (U+007F)
-        $this->invalidParseErrorTestHandler("\x7F", 1, 'U+007F');
+        $this->invalidParseErrorTestHandler("\x7F", 0, 'U+007F');
 
         // C1 Controls
-        $this->invalidParseErrorTestHandler("\xC2\x80", 1, 'U+0080 (C1 control)');
-        $this->invalidParseErrorTestHandler("\xC2\x9F", 1, 'U+009F (C1 control)');
-        $this->invalidParseErrorTestHandler("\xC2\xA0", 0, 'U+00A0 (first codepoint above highest C1 control)');
+        $this->invalidParseErrorTestHandler("\xC2\x80", 1, 'U+0080 (C1 control)', "\xC2\x80");
+        $this->invalidParseErrorTestHandler("\xC2\x9F", 1, 'U+009F (C1 control)', "\xC2\x9F");
+        $this->invalidParseErrorTestHandler("\xC2\xA0", 0, 'U+00A0 (first codepoint above highest C1 control)', "\xC2\xA0");
 
         // Charcters surrounding surrogates
-        $this->invalidParseErrorTestHandler("\xED\x9F\xBF", 0, 'U+D7FF (one codepoint below lowest surrogate codepoint)');
+        $this->invalidParseErrorTestHandler("\xED\x9F\xBF", 0, 'U+D7FF (one codepoint below lowest surrogate codepoint)', "\xED\x9F\xBF");
         $this->invalidParseErrorTestHandler("\xEF\xBF\xBD", 0, 'U+DE00 (one codepoint above highest surrogate codepoint)');
 
         // Permanent noncharacters
-        $this->invalidParseErrorTestHandler("\xEF\xB7\x90", 1, 'U+FDD0 (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xEF\xB7\xAF", 1, 'U+FDEF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xEF\xBF\xBE", 1, 'U+FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xEF\xBF\xBF", 1, 'U+FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF0\x9F\xBF\xBE", 1, 'U+1FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF0\x9F\xBF\xBF", 1, 'U+1FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF0\xAF\xBF\xBE", 1, 'U+2FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF0\xAF\xBF\xBF", 1, 'U+2FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF0\xBF\xBF\xBE", 1, 'U+3FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF0\xBF\xBF\xBF", 1, 'U+3FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF1\x8F\xBF\xBE", 1, 'U+4FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF1\x8F\xBF\xBF", 1, 'U+4FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF1\x9F\xBF\xBE", 1, 'U+5FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF1\x9F\xBF\xBF", 1, 'U+5FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF1\xAF\xBF\xBE", 1, 'U+6FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF1\xAF\xBF\xBF", 1, 'U+6FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF1\xBF\xBF\xBE", 1, 'U+7FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF1\xBF\xBF\xBF", 1, 'U+7FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF2\x8F\xBF\xBE", 1, 'U+8FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF2\x8F\xBF\xBF", 1, 'U+8FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF2\x9F\xBF\xBE", 1, 'U+9FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF2\x9F\xBF\xBF", 1, 'U+9FFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF2\xAF\xBF\xBE", 1, 'U+AFFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF2\xAF\xBF\xBF", 1, 'U+AFFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF2\xBF\xBF\xBE", 1, 'U+BFFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF2\xBF\xBF\xBF", 1, 'U+BFFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF3\x8F\xBF\xBE", 1, 'U+CFFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF3\x8F\xBF\xBF", 1, 'U+CFFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF3\x9F\xBF\xBE", 1, 'U+DFFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF3\x9F\xBF\xBF", 1, 'U+DFFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF3\xAF\xBF\xBE", 1, 'U+EFFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF3\xAF\xBF\xBF", 1, 'U+EFFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF3\xBF\xBF\xBE", 1, 'U+FFFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF3\xBF\xBF\xBF", 1, 'U+FFFFF (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF4\x8F\xBF\xBE", 1, 'U+10FFFE (permanent noncharacter)');
-        $this->invalidParseErrorTestHandler("\xF4\x8F\xBF\xBF", 1, 'U+10FFFF (permanent noncharacter)');
+        $this->invalidParseErrorTestHandler("\xEF\xB7\x90", 1, 'U+FDD0 (permanent noncharacter)', "\xEF\xB7\x90");
+        $this->invalidParseErrorTestHandler("\xEF\xB7\xAF", 1, 'U+FDEF (permanent noncharacter)', "\xEF\xB7\xAF");
+        $this->invalidParseErrorTestHandler("\xEF\xBF\xBE", 1, 'U+FFFE (permanent noncharacter)', "\xEF\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xEF\xBF\xBF", 1, 'U+FFFF (permanent noncharacter)', "\xEF\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF0\x9F\xBF\xBE", 1, 'U+1FFFE (permanent noncharacter)', "\xF0\x9F\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF0\x9F\xBF\xBF", 1, 'U+1FFFF (permanent noncharacter)', "\xF0\x9F\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF0\xAF\xBF\xBE", 1, 'U+2FFFE (permanent noncharacter)', "\xF0\xAF\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF0\xAF\xBF\xBF", 1, 'U+2FFFF (permanent noncharacter)', "\xF0\xAF\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF0\xBF\xBF\xBE", 1, 'U+3FFFE (permanent noncharacter)', "\xF0\xBF\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF0\xBF\xBF\xBF", 1, 'U+3FFFF (permanent noncharacter)', "\xF0\xBF\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF1\x8F\xBF\xBE", 1, 'U+4FFFE (permanent noncharacter)', "\xF1\x8F\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF1\x8F\xBF\xBF", 1, 'U+4FFFF (permanent noncharacter)', "\xF1\x8F\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF1\x9F\xBF\xBE", 1, 'U+5FFFE (permanent noncharacter)', "\xF1\x9F\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF1\x9F\xBF\xBF", 1, 'U+5FFFF (permanent noncharacter)', "\xF1\x9F\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF1\xAF\xBF\xBE", 1, 'U+6FFFE (permanent noncharacter)', "\xF1\xAF\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF1\xAF\xBF\xBF", 1, 'U+6FFFF (permanent noncharacter)', "\xF1\xAF\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF1\xBF\xBF\xBE", 1, 'U+7FFFE (permanent noncharacter)', "\xF1\xBF\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF1\xBF\xBF\xBF", 1, 'U+7FFFF (permanent noncharacter)', "\xF1\xBF\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF2\x8F\xBF\xBE", 1, 'U+8FFFE (permanent noncharacter)', "\xF2\x8F\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF2\x8F\xBF\xBF", 1, 'U+8FFFF (permanent noncharacter)', "\xF2\x8F\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF2\x9F\xBF\xBE", 1, 'U+9FFFE (permanent noncharacter)', "\xF2\x9F\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF2\x9F\xBF\xBF", 1, 'U+9FFFF (permanent noncharacter)', "\xF2\x9F\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF2\xAF\xBF\xBE", 1, 'U+AFFFE (permanent noncharacter)', "\xF2\xAF\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF2\xAF\xBF\xBF", 1, 'U+AFFFF (permanent noncharacter)', "\xF2\xAF\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF2\xBF\xBF\xBE", 1, 'U+BFFFE (permanent noncharacter)', "\xF2\xBF\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF2\xBF\xBF\xBF", 1, 'U+BFFFF (permanent noncharacter)', "\xF2\xBF\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF3\x8F\xBF\xBE", 1, 'U+CFFFE (permanent noncharacter)', "\xF3\x8F\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF3\x8F\xBF\xBF", 1, 'U+CFFFF (permanent noncharacter)', "\xF3\x8F\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF3\x9F\xBF\xBE", 1, 'U+DFFFE (permanent noncharacter)', "\xF3\x9F\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF3\x9F\xBF\xBF", 1, 'U+DFFFF (permanent noncharacter)', "\xF3\x9F\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF3\xAF\xBF\xBE", 1, 'U+EFFFE (permanent noncharacter)', "\xF3\xAF\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF3\xAF\xBF\xBF", 1, 'U+EFFFF (permanent noncharacter)', "\xF3\xAF\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF3\xBF\xBF\xBE", 1, 'U+FFFFE (permanent noncharacter)', "\xF3\xBF\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF3\xBF\xBF\xBF", 1, 'U+FFFFF (permanent noncharacter)', "\xF3\xBF\xBF\xBF");
+        $this->invalidParseErrorTestHandler("\xF4\x8F\xBF\xBE", 1, 'U+10FFFE (permanent noncharacter)', "\xF4\x8F\xBF\xBE");
+        $this->invalidParseErrorTestHandler("\xF4\x8F\xBF\xBF", 1, 'U+10FFFF (permanent noncharacter)', "\xF4\x8F\xBF\xBF");
 
-        // MPB: These pass on some versions of iconv, and fail on others. Since we aren't in the
-        // business of writing tests against iconv, I've just commented these out. Should revisit
-        // at a later point.
-        /*
-         * $this->invalidParseErrorTestHandler("\xED\xA0\x80", 1, 'U+D800 (UTF-16 surrogate character)'); $this->invalidParseErrorTestHandler("\xED\xAD\xBF", 1, 'U+DB7F (UTF-16 surrogate character)'); $this->invalidParseErrorTestHandler("\xED\xAE\x80", 1, 'U+DB80 (UTF-16 surrogate character)'); $this->invalidParseErrorTestHandler("\xED\xAF\xBF", 1, 'U+DBFF (UTF-16 surrogate character)'); $this->invalidParseErrorTestHandler("\xED\xB0\x80", 1, 'U+DC00 (UTF-16 surrogate character)'); $this->invalidParseErrorTestHandler("\xED\xBE\x80", 1, 'U+DF80 (UTF-16 surrogate character)'); $this->invalidParseErrorTestHandler("\xED\xBF\xBF", 1, 'U+DFFF (UTF-16 surrogate character)'); // Paired UTF-16 surrogates $this->invalidParseErrorTestHandler("\xED\xA0\x80\xED\xB0\x80", 2, 'U+D800 U+DC00 (paired UTF-16 surrogates)'); $this->invalidParseErrorTestHandler("\xED\xA0\x80\xED\xBF\xBF", 2, 'U+D800 U+DFFF (paired UTF-16 surrogates)'); $this->invalidParseErrorTestHandler("\xED\xAD\xBF\xED\xB0\x80", 2, 'U+DB7F U+DC00 (paired UTF-16 surrogates)'); $this->invalidParseErrorTestHandler("\xED\xAD\xBF\xED\xBF\xBF", 2, 'U+DB7F U+DFFF (paired UTF-16 surrogates)'); $this->invalidParseErrorTestHandler("\xED\xAE\x80\xED\xB0\x80", 2, 'U+DB80 U+DC00 (paired UTF-16 surrogates)'); $this->invalidParseErrorTestHandler("\xED\xAE\x80\xED\xBF\xBF", 2, 'U+DB80 U+DFFF (paired UTF-16 surrogates)'); $this->invalidParseErrorTestHandler("\xED\xAF\xBF\xED\xB0\x80", 2, 'U+DBFF U+DC00 (paired UTF-16 surrogates)'); $this->invalidParseErrorTestHandler("\xED\xAF\xBF\xED\xBF\xBF", 2, 'U+DBFF U+DFFF (paired UTF-16 surrogates)');
-         */
+        $this->invalidParseErrorTestHandler("\xED\xA0\x80", 0, 'U+D800 (UTF-16 surrogate character)');
+        $this->invalidParseErrorTestHandler("\xED\xAD\xBF", 0, 'U+DB7F (UTF-16 surrogate character)');
+        $this->invalidParseErrorTestHandler("\xED\xAE\x80", 0, 'U+DB80 (UTF-16 surrogate character)');
+        $this->invalidParseErrorTestHandler("\xED\xAF\xBF", 0, 'U+DBFF (UTF-16 surrogate character)');
+        $this->invalidParseErrorTestHandler("\xED\xB0\x80", 0, 'U+DC00 (UTF-16 surrogate character)');
+        $this->invalidParseErrorTestHandler("\xED\xBE\x80", 0, 'U+DF80 (UTF-16 surrogate character)');
+        $this->invalidParseErrorTestHandler("\xED\xBF\xBF", 0, 'U+DFFF (UTF-16 surrogate character)'); // Paired UTF-16 surrogates
+        $this->invalidParseErrorTestHandler("\xED\xA0\x80\xED\xB0\x80", 0, 'U+D800 U+DC00 (paired UTF-16 surrogates)');
+        $this->invalidParseErrorTestHandler("\xED\xA0\x80\xED\xBF\xBF", 0, 'U+D800 U+DFFF (paired UTF-16 surrogates)');
+        $this->invalidParseErrorTestHandler("\xED\xAD\xBF\xED\xB0\x80", 0, 'U+DB7F U+DC00 (paired UTF-16 surrogates)');
+        $this->invalidParseErrorTestHandler("\xED\xAD\xBF\xED\xBF\xBF", 0, 'U+DB7F U+DFFF (paired UTF-16 surrogates)');
+        $this->invalidParseErrorTestHandler("\xED\xAE\x80\xED\xB0\x80", 0, 'U+DB80 U+DC00 (paired UTF-16 surrogates)');
+        $this->invalidParseErrorTestHandler("\xED\xAE\x80\xED\xBF\xBF", 0, 'U+DB80 U+DFFF (paired UTF-16 surrogates)');
+        $this->invalidParseErrorTestHandler("\xED\xAF\xBF\xED\xB0\x80", 0, 'U+DBFF U+DC00 (paired UTF-16 surrogates)');
+        $this->invalidParseErrorTestHandler("\xED\xAF\xBF\xED\xBF\xBF", 0, 'U+DBFF U+DFFF (paired UTF-16 surrogates)');
     }
 }

--- a/test/HTML5/Parser/TokenizerTest.php
+++ b/test/HTML5/Parser/TokenizerTest.php
@@ -199,7 +199,9 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
             '<!-- --$i -->' => ' --$i ',
             '<!----$i-->' => '--$i',
             "<!--\nHello World.\na-->" => "\nHello World.\na",
-            '<!-- <!-- -->' => ' <!-- '
+            "<!--\0Hello-->" => 'Hello',
+            "<!--" . UTF8Utils::FFFD . 'Hello-->' => 'Hello',
+            '<!-- <!-- -->' => ' <!-- ',
         );
         foreach ($good as $test => $expected) {
             $events = $this->parse($test);
@@ -209,7 +211,6 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
         $fail = array(
             '<!-->' => '',
             '<!--Hello' => 'Hello',
-            "<!--\0Hello" => UTF8Utils::FFFD . 'Hello',
             '<!--' => ''
         );
         foreach ($fail as $test => $expected) {
@@ -854,6 +855,8 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
             '<script><not/><the/><tag></script>' => '<not/><the/><tag>',
             '<script><<<<<<<<</script>' => '<<<<<<<<',
             '<script>hello</script</script>' => 'hello</script',
+            "<script>\0Hello</script>" => 'Hello',
+            '<script>' . UTF8Utils::FFFD . 'Hello</script>' => 'Hello',
             "<script>\nhello</script\n</script>" => "\nhello</script\n",
             '<script>&amp;</script>' => '&amp;',
             '<script><!--not a comment--></script>' => '<!--not a comment-->',

--- a/test/HTML5/Parser/TreeBuildingRulesTest.php
+++ b/test/HTML5/Parser/TreeBuildingRulesTest.php
@@ -5,11 +5,11 @@
  */
 namespace Masterminds\HTML5\Tests\Parser;
 
-use Masterminds\HTML5\Parser\TreeBuildingRules;
-use Masterminds\HTML5\Parser\Tokenizer;
+use Masterminds\HTML5\Parser\DOMTreeBuilder;
 use Masterminds\HTML5\Parser\Scanner;
 use Masterminds\HTML5\Parser\StringInputStream;
-use Masterminds\HTML5\Parser\DOMTreeBuilder;
+use Masterminds\HTML5\Parser\Tokenizer;
+use Masterminds\HTML5\Parser\TreeBuildingRules;
 
 /**
  * These tests are functional, not necessarily unit tests.
@@ -31,6 +31,7 @@ class TreeBuildingRulesTest extends \Masterminds\HTML5\Tests\TestCase
         $parser->parse();
         return $treeBuilder->document();
     }
+
     /**
      * Convenience function for parsing fragments.
      */
@@ -51,9 +52,9 @@ class TreeBuildingRulesTest extends \Masterminds\HTML5\Tests\TestCase
 
         $td = $frag->childNodes->item(0);
 
-        $this->assertEquals(1, $frag->childNodes->length);
-        $this->assertEquals('td', $td->tagName);
-        $this->assertEquals('This is a test of the HTML5 parser', $td->nodeValue);
+        self::assertSame(1, $frag->childNodes->length);
+        self::assertSame('td', $td->tagName);
+        self::assertSame('This is a test of the HTML5 parser', $td->nodeValue);
     }
 
     public function testHasRules()
@@ -61,8 +62,8 @@ class TreeBuildingRulesTest extends \Masterminds\HTML5\Tests\TestCase
         $doc = new \DOMDocument('1.0');
         $engine = new TreeBuildingRules($doc);
 
-        $this->assertTrue($engine->hasRules('li'));
-        $this->assertFalse($engine->hasRules('imaginary'));
+        self::assertTrue($engine->hasRules('li'));
+        self::assertFalse($engine->hasRules('imaginary'));
     }
 
     public function testHandleLI()
@@ -72,9 +73,9 @@ class TreeBuildingRulesTest extends \Masterminds\HTML5\Tests\TestCase
 
         $list = $doc->getElementById('a');
 
-        $this->assertEquals(2, $list->childNodes->length);
+        self::assertEquals(2, $list->childNodes->length);
         foreach ($list->childNodes as $ele) {
-            $this->assertEquals('li', $ele->tagName);
+            self::assertEquals('li', $ele->tagName);
         }
     }
 
@@ -85,9 +86,9 @@ class TreeBuildingRulesTest extends \Masterminds\HTML5\Tests\TestCase
 
         $list = $doc->getElementById('a');
 
-        $this->assertEquals(2, $list->childNodes->length);
-        $this->assertEquals('dt', $list->firstChild->tagName);
-        $this->assertEquals('dd', $list->lastChild->tagName);
+        self::assertEquals(2, $list->childNodes->length);
+        self::assertEquals('dt', $list->firstChild->tagName);
+        self::assertEquals('dd', $list->lastChild->tagName);
     }
 
     public function testHandleOptionGroupAndOption()
@@ -97,10 +98,10 @@ class TreeBuildingRulesTest extends \Masterminds\HTML5\Tests\TestCase
 
         $list = $doc->getElementById('foo');
 
-        $this->assertEquals(1, $list->childNodes->length);
+        self::assertEquals(1, $list->childNodes->length);
 
         $option = $list->childNodes->item(0);
-        $this->assertEquals('option', $option->tagName);
+        self::assertEquals('option', $option->tagName);
     }
 
     public function testTable()
@@ -110,8 +111,8 @@ class TreeBuildingRulesTest extends \Masterminds\HTML5\Tests\TestCase
 
         $list = $doc->getElementById('a');
 
-        $this->assertEquals(3, $list->childNodes->length);
-        $this->assertEquals('th', $list->firstChild->tagName);
-        $this->assertEquals('td', $list->lastChild->tagName);
+        self::assertEquals(3, $list->childNodes->length);
+        self::assertEquals('th', $list->firstChild->tagName);
+        self::assertEquals('td', $list->lastChild->tagName);
     }
 }

--- a/test/HTML5/Parser/UTF8UtilsTest.php
+++ b/test/HTML5/Parser/UTF8UtilsTest.php
@@ -6,21 +6,23 @@ use Masterminds\HTML5\Parser\UTF8Utils;
 
 class UTF8UtilsTest extends \Masterminds\HTML5\Tests\TestCase
 {
-	public function testConvertToUTF8() {
-		$out = UTF8Utils::convertToUTF8('éàa', 'ISO-8859-1');
-		$this->assertEquals('Ã©Ã a', $out);
-	}
+    public function testConvertToUTF8()
+    {
+        $out = UTF8Utils::convertToUTF8('éàa', 'ISO-8859-1');
+        self::assertEquals('a', $out);
+    }
 
-	/**
-	 * @todo add tests for invalid codepoints
-	 */
-	public function testCheckForIllegalCodepoints() {
-		$smoke = "Smoke test";
-		$err = UTF8Utils::checkForIllegalCodepoints($smoke);
-		$this->assertEmpty($err);
+    /**
+     * @todo add tests for invalid codepoints
+     */
+    public function testCheckForIllegalCodepoints()
+    {
+        $smoke = "Smoke test";
+        $err = UTF8Utils::checkForIllegalCodepoints($smoke);
+        self::assertEmpty($err);
 
-		$data = "Foo Bar \0 Baz";
-		$errors = UTF8Utils::checkForIllegalCodepoints($data);
-		$this->assertContains('null-character', $errors);
-	}
+        $data = "Foo Bar \0 Baz";
+        $errors = UTF8Utils::checkForIllegalCodepoints($data);
+        self::assertContains('null-character', $errors);
+    }
 }

--- a/test/HTML5/Serializer/TraverserTest.php
+++ b/test/HTML5/Serializer/TraverserTest.php
@@ -1,12 +1,16 @@
 <?php
 namespace Masterminds\HTML5\Tests\Serializer;
 
+use Masterminds\HTML5;
 use Masterminds\HTML5\Serializer\OutputRules;
 use Masterminds\HTML5\Serializer\Traverser;
-use Masterminds\HTML5\Parser;
 
 class TraverserTest extends \Masterminds\HTML5\Tests\TestCase
 {
+    /**
+     * @var HTML5
+     */
+    private $html5;
 
     protected $markup = '<!doctype html>
     <html lang="en">
@@ -46,7 +50,7 @@ class TraverserTest extends \Masterminds\HTML5\Tests\TestCase
         $stream = fopen('php://temp', 'w');
 
         $dom = $this->html5->loadHTML($this->markup);
-        $t = new Traverser($dom, $stream, $html5->getOptions());
+        $t = new Traverser($dom, $stream, $this->html5->getOptions());
 
         // We return both the traverser and stream so we can pull from it.
         return array(
@@ -68,7 +72,7 @@ class TraverserTest extends \Masterminds\HTML5\Tests\TestCase
 
         $t = new Traverser($dom, $stream, $r, $html5->getOptions());
 
-        $this->assertInstanceOf('\Masterminds\HTML5\Serializer\Traverser', $t);
+        self::assertInstanceOf('\Masterminds\HTML5\Serializer\Traverser', $t);
     }
 
     public function testFragment()
@@ -77,14 +81,14 @@ class TraverserTest extends \Masterminds\HTML5\Tests\TestCase
         $input = new \Masterminds\HTML5\Parser\StringInputStream($html);
         $dom = $this->html5->parseFragment($input);
 
-        $this->assertInstanceOf('\DOMDocumentFragment', $dom);
+        self::assertInstanceOf('\DOMDocumentFragment', $dom);
 
         $stream = fopen('php://temp', 'w');
         $r = new OutputRules($stream, $this->html5->getOptions());
         $t = new Traverser($dom, $stream, $r, $this->html5->getOptions());
 
         $out = $t->walk();
-        $this->assertEquals($html, stream_get_contents($stream, - 1, 0));
+        self::assertEquals($html, stream_get_contents($stream, -1, 0));
     }
 
     public function testProcessorInstruction()
@@ -93,13 +97,13 @@ class TraverserTest extends \Masterminds\HTML5\Tests\TestCase
         $input = new \Masterminds\HTML5\Parser\StringInputStream($html);
         $dom = $this->html5->parseFragment($input);
 
-        $this->assertInstanceOf('\DOMDocumentFragment', $dom);
+        self::assertInstanceOf('\DOMDocumentFragment', $dom);
 
         $stream = fopen('php://temp', 'w');
         $r = new OutputRules($stream, $this->html5->getOptions());
         $t = new Traverser($dom, $stream, $r, $this->html5->getOptions());
 
         $out = $t->walk();
-        $this->assertEquals($html, stream_get_contents($stream, - 1, 0));
+        self::assertEquals($html, stream_get_contents($stream, -1, 0));
     }
 }


### PR DESCRIPTION
1. "CharacterReference::lookupDecimal()" -> is using "UTF8::decimal_to_chr()"
2. "CharacterReference::lookupHex()" -> is using "UTF8::hex_to_chr()"
3. "CharacterReference::lookupName()" -> use fallback via "UTF8::html_entity_decode('&' . $name . ';')"
4. "UTF8Utils::countChars()" -> is using "UTF8::strlen()" (but internally the method isn't used anymore)
5. "UTF8Utils::convertToUTF8()" -> is using "UTF8::encode()" + "UTF8::clean()"
6. use strict type-checks for e.g. int, string, array [in_array()] etc.
7. use UTF-8 safe string-functions + polyfills

---
If this are too much changes at once, I can also try summit some small fixes ...