### PR TITLE
Optimized Tokenizer.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,22 @@
 language: php
 
-# Setting sudo access to false will let Travis CI use containers rather than
-# VMs to run the tests. For more details see:
-# - http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-# - http://docs.travis-ci.com/user/workers/standard-infrastructure/
 sudo: false
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
+
+matrix:
+    include:
+        - php: 5.3
+          dist: precise
+    fast_finish: true
+
+dist: trusty
 
 cache:
   directories:

--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -1071,7 +1071,7 @@ class Tokenizer
         else {
             // Attempt to consume a string up to a ';'.
             // [a-zA-Z0-9]+;
-            $cname = $this->scanner->getAsciiAlpha();
+            $cname = $this->scanner->getAsciiAlphaNum();
             $entity = CharacterReference::lookupName($cname);
 
             // When no entity is found provide the name of the unmatched string

--- a/test/HTML5/Parser/TokenizerTest.php
+++ b/test/HTML5/Parser/TokenizerTest.php
@@ -940,6 +940,10 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
         $events = $this->parse('a&amp;b');
         $this->assertEquals(2, $events->depth(), "Events: " . print_r($events, true));
         $this->assertEventEquals('text', 'a&b', $events->get(0));
+
+        $events = $this->parse('a&sup2;b');
+        $this->assertEquals(2, $events->depth(), "Events: " . print_r($events, true));
+        $this->assertEventEquals('text', 'a²b', $events->get(0));
     }
 
     // ================================================================


### PR DESCRIPTION
I am working on a project where we parse several thousand HTML5 pages with this library.
When profiling the code with xdebug, I noticed extreme amounts of calls to the scanner's .current() and .next() functions. Here is my attempt to optimize the tokenizer code.

Run time comparison:
Original Code: 281s
Only with the optimized quotedAttributeValue() function: 242s
With all optimizations:  226s 

-> Saves about ~60s / 20%