### PR TITLE
Raw & in attributes

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -1067,8 +1067,10 @@ class Tokenizer
                 }
                 $entity = CharacterReference::lookupDecimal($numeric);
             }
-        }         // String entity.
-        else {
+        } elseif ($tok === '=' && $inAttribute) {
+            return '&';
+        } else { // String entity.
+
             // Attempt to consume a string up to a ';'.
             // [a-zA-Z0-9]+;
             $cname = $this->scanner->getAsciiAlphaNum();
@@ -1078,7 +1080,9 @@ class Tokenizer
             // and continue on as the & is not part of an entity. The & will
             // be converted to &amp; elsewhere.
             if ($entity == null) {
-                $this->parseError("No match in entity table for '%s'", $cname);
+                if (!$inAttribute || strlen($cname) === 0) {
+                    $this->parseError("No match in entity table for '%s'", $cname);
+                }
                 $this->scanner->unconsume($this->scanner->position() - $start);
                 return '&';
             }

--- a/test/HTML5/Parser/DOMTreeBuilderTest.php
+++ b/test/HTML5/Parser/DOMTreeBuilderTest.php
@@ -58,6 +58,80 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $this->assertEquals('http://www.w3.org/1999/xhtml', $doc->documentElement->namespaceURI);
     }
 
+    public function testBareAmpersand()
+    {
+        $html = "<!doctype html>
+        <html>
+            <body> 
+                <img src='a&b' />
+                <img src='a&=' />
+                <img src='a&=c' />
+                <img src='a&=9' />
+            </body>
+        </html>";
+        $doc = $this->parse($html);
+
+        $this->assertEmpty($this->errors);
+        $this->assertXmlStringEqualsXmlString('
+        <!DOCTYPE html>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body> 
+                <img src="a&amp;b"/>
+                <img src="a&amp;="/>
+                <img src="a&amp;=c"/>
+                <img src="a&amp;=9"/>
+            </body>
+        </html>', $doc->saveXML());
+    }
+
+    public function testBareAmpersandNotAllowedInAttributes()
+    {
+        $html = "<!doctype html>
+        <html>
+            <body>
+                <img src='a&' />
+                <img src='a&+' />
+            </body>
+        </html>";
+        $doc = $this->parse($html);
+
+        $this->assertCount(2, $this->errors);
+        $this->assertXmlStringEqualsXmlString('
+        <!DOCTYPE html>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body> 
+                <img src="a&amp;"/>
+                <img src="a&amp;+"/>
+            </body>
+        </html>', $doc->saveXML());
+    }
+    public function testBareAmpersandNotAllowedInBody()
+    {
+        $html = "<!doctype html>
+        <html>
+            <body> 
+                a&b
+                a&=
+                a&=c
+                a&=9
+                a&+
+                a& -- valid
+            </body>
+        </html>";
+        $doc = $this->parse($html);
+
+        $this->assertCount(5, $this->errors);
+        $this->assertXmlStringEqualsXmlString('
+        <!DOCTYPE html>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body> 
+                a&amp;b
+                a&amp;=
+                a&amp;=c
+                a&amp;=9
+                a&amp;+
+                a&amp; -- valid
+            </body>
+        </html>', $doc->saveXML());
+    }
+
     public function testStrangeCapitalization()
     {
         $html = "<!doctype html>

--- a/test/HTML5/Parser/TokenizerTest.php
+++ b/test/HTML5/Parser/TokenizerTest.php
@@ -622,10 +622,24 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
                 ),
                 false
             ),
+            "<foo a='blue&red'>" => array(
+                'foo',
+                array(
+                    'a' => 'blue&red'
+                ),
+                false
+            ),
             "<foo a='blue&amp;red'>" => array(
                 'foo',
                 array(
                     'a' => 'blue&red'
+                ),
+                false
+            ),
+            "<foo a='blue&&amp;&red'>" => array(
+                'foo',
+                array(
+                    'a' => 'blue&&&red'
                 ),
                 false
             ),
@@ -725,18 +739,11 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
 
         // Cause a parse error.
         $bad = array(
-            // This will emit an entity lookup failure for &red.
-            "<foo a='blue&red'>" => array(
+            // This will emit an entity lookup failure for &+dark.
+            "<foo a='blue&+dark'>" => array(
                 'foo',
                 array(
-                    'a' => 'blue&red'
-                ),
-                false
-            ),
-            "<foo a='blue&&amp;&red'>" => array(
-                'foo',
-                array(
-                    'a' => 'blue&&&red'
+                    'a' => 'blue&+dark'
                 ),
                 false
             ),


### PR DESCRIPTION
Fixes #124 

Tries to implement the HTML spec: 
https://www.w3.org/TR/html52/syntax.html#character-reference-state

More specifically:

> If the character reference was consumed as part of an attribute (return state is either attribute value (double-quoted) state, attribute value (single-quoted) state or attribute value (unquoted) state), and the last character matched is not a U+003B SEMICOLON character (;), and the next input character is either a U+003D EQUALS SIGN character (=) or an alphanumeric ASCII character, then, for historical reasons, switch to the character reference end state.