### PR TITLE
Tokenizer performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ script:
 after_script:
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] ; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] ; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi;'
+  - php test/benchmark/run.php 50

--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -83,11 +83,8 @@ class Tokenizer
      */
     public function parse()
     {
-        $p = 0;
         do {
-            $p = $this->scanner->position();
             $this->consumeData();
-
             // FIXME: Add infinite loop protection.
         } while ($this->carryOn);
     }
@@ -145,7 +142,8 @@ class Tokenizer
      */
     protected function characterData()
     {
-        if ($this->scanner->current() === false) {
+        $tok = $this->scanner->current();
+        if ($tok === false) {
             return false;
         }
         switch ($this->textMode) {
@@ -154,7 +152,6 @@ class Tokenizer
             case Elements::TEXT_RCDATA:
                 return $this->rcdata();
             default:
-                $tok = $this->scanner->current();
                 if (strspn($tok, "<&")) {
                     return false;
                 }
@@ -408,24 +405,26 @@ class Tokenizer
         if ($tok == '/') {
             $this->scanner->next();
             $this->scanner->whitespace();
-            if ($this->scanner->current() == '>') {
+            $tok = $this->scanner->current();
+
+            if ($tok == '>') {
                 $selfClose = true;
                 return true;
             }
-            if ($this->scanner->current() === false) {
+            if ($tok === false) {
                 $this->parseError("Unexpected EOF inside of tag.");
                 return true;
             }
             // Basically, we skip the / token and go on.
             // See 8.2.4.43.
-            $this->parseError("Unexpected '%s' inside of a tag.", $this->scanner->current());
+            $this->parseError("Unexpected '%s' inside of a tag.", $tok);
             return false;
         }
 
-        if ($this->scanner->current() == '>') {
+        if ($tok == '>') {
             return true;
         }
-        if ($this->scanner->current() === false) {
+        if ($tok === false) {
             $this->parseError("Unexpected EOF inside of tag.");
             return true;
         }
@@ -541,15 +540,21 @@ class Tokenizer
     {
         $stoplist = "\f" . $quote;
         $val = '';
-        $tok = $this->scanner->current();
-        while (strspn($tok, $stoplist) == 0 && $tok !== false) {
-            if ($tok == '&') {
-                $val .= $this->decodeCharacterReference(true);
-                $tok = $this->scanner->current();
+
+        while (true) {
+            $tokens = $this->scanner->charsUntil($stoplist.'&');
+            if ($tokens !== false) {
+                $val .= $tokens;
             } else {
-                $val .= $tok;
-                $tok = $this->scanner->next();
+                break;
             }
+
+            $tok = $this->scanner->current();
+            if ($tok == '&') {
+                $val .= $this->decodeCharacterReference(true, $tok);
+                continue;
+            }
+            break;
         }
         $this->scanner->next();
         return $val;
@@ -591,18 +596,18 @@ class Tokenizer
      */
     protected function bogusComment($leading = '')
     {
-
-        // TODO: This can be done more efficiently when the
-        // scanner exposes a readUntil() method.
         $comment = $leading;
+        $tokens = $this->scanner->charsUntil('>');
+        if ($tokens !== false) {
+            $comment .= $tokens;
+        }
         $tok = $this->scanner->current();
-        do {
+        if ($tok !== false) {
             $comment .= $tok;
-            $tok = $this->scanner->next();
-        } while ($tok !== false && $tok != '>');
+        }
 
         $this->flushBuffer();
-        $this->events->comment($comment . $tok);
+        $this->events->comment($comment);
         $this->scanner->next();
 
         return true;
@@ -646,15 +651,17 @@ class Tokenizer
      */
     protected function isCommentEnd()
     {
+        $tok = $this->scanner->current();
+
         // EOF
-        if ($this->scanner->current() === false) {
+        if ($tok === false) {
             // Hit the end.
             $this->parseError("Unexpected EOF in a comment.");
             return true;
         }
 
         // If it doesn't start with -, not the end.
-        if ($this->scanner->current() != '-') {
+        if ($tok != '-') {
             return false;
         }
 
@@ -737,7 +744,6 @@ class Tokenizer
 
         $pub = strtoupper($this->scanner->getAsciiAlpha());
         $white = strlen($this->scanner->whitespace());
-        $tok = $this->scanner->current();
 
         // Get ID, and flag it as pub or system.
         if (($pub == 'PUBLIC' || $pub == 'SYSTEM') && $white > 0) {
@@ -938,10 +944,11 @@ class Tokenizer
         $len = strlen($sequence);
         $buffer = '';
         for ($i = 0; $i < $len; ++ $i) {
-            $buffer .= $this->scanner->current();
+            $tok = $this->scanner->current();
+            $buffer .= $tok;
 
             // EOF. Rewind and let the caller handle it.
-            if ($this->scanner->current() === false) {
+            if ($tok === false) {
                 $this->scanner->unconsume($i);
                 return false;
             }

--- a/test/benchmark/example.html
+++ b/test/benchmark/example.html
@@ -1,0 +1,6403 @@
+
+<!DOCTYPE html>
+<!--[if (gt IE 9)|!(IE)]> <!--> <html lang="en" class="no-js edition-domestic app-homepage"  itemscope xmlns:og="http://opengraphprotocol.org/schema/"> <!--<![endif]-->
+<!--[if IE 9]> <html lang="en" class="no-js ie9 lt-ie10 edition-domestic app-homepage" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
+<!--[if IE 8]> <html lang="en" class="no-js ie8 lt-ie10 lt-ie9 edition-domestic app-homepage" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
+<!--[if (lt IE 8)]> <html lang="en" class="no-js lt-ie10 lt-ie9 lt-ie8 edition-domestic app-homepage" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
+<head>
+    <title>The New York Times - Breaking News, World News & Multimedia</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <link rel="shortcut icon" href="https://static01.nyt.com/favicon.ico" />
+    <link rel="apple-touch-icon-precomposed" sizes="144×144" href="https://static01.nyt.com/images/icons/ios-ipad-144x144.png" />
+    <link rel="apple-touch-icon-precomposed" sizes="114×114" href="https://static01.nyt.com/images/icons/ios-iphone-114x144.png" />
+    <link rel="apple-touch-icon-precomposed" href="https://static01.nyt.com/images/icons/ios-default-homescreen-57x57.png" />
+    <meta name="sourceApp" content="nyt-v5" />
+    <meta id="applicationName" name="applicationName" content="homepage" />
+    <meta id="foundation-build-id" name="foundation-build-id" content="" />
+    <link rel="canonical" href="https://www.nytimes.com" />
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml" />
+    <link rel="alternate" media="only screen and (max-width: 640px)" href="http://mobile.nytimes.com" />
+    <link rel="alternate" media="handheld" href="http://mobile.nytimes.com" />
+    <meta name="robots" content="noarchive,noodp,noydir" />
+    <meta name="description" content="The New York Times: Find breaking news, multimedia, reviews & opinion on Washington, business, sports, movies, travel, books, jobs, education, real estate, cars & more at nytimes.com." />
+    <meta name="CG" content="Homepage" />
+    <meta name="SCG" content="" />
+    <meta name="PT" content="Homepage" />
+    <meta name="PST" content="" />
+    <meta name="application-name" content="The New York Times" />
+    <meta name="msapplication-starturl" content="https://www.nytimes.com" />
+    <meta name="msapplication-task" content="name=Search;action-uri=http://query.nytimes.com/search/sitesearch?src=iepin;icon-uri=https://static01.nyt.com/images/icons/search.ico" />
+    <meta name="msapplication-task" content="name=Most Popular;action-uri=http://www.nytimes.com/gst/mostpopular.html?src=iepin;icon-uri=https://static01.nyt.com/images/icons/mostpopular.ico" />
+    <meta name="msapplication-task" content="name=Video;action-uri=http://video.nytimes.com/?src=iepin;icon-uri=https://static01.nyt.com/images/icons/video.ico" />
+    <meta name="msapplication-task" content="name=Homepage;action-uri=https://www.nytimes.com?src=iepin&amp;adxnnl=1;icon-uri=https://static01.nyt.com/images/icons/homepage.ico" />
+    <meta property="og:url" content="https://www.nytimes.com" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Breaking News, World News & Multimedia" />
+    <meta property="og:description" content="The New York Times: Find breaking news, multimedia, reviews & opinion on Washington, business, sports, movies, travel, books, jobs, education, real estate, cars & more at nytimes.com." />
+    <meta property="og:image" content="https://static01.nyt.com/images/icons/t_logo_291_black.png" />
+    <meta property="fb:app_id" content="9869919170" />
+    <meta name="apple-itunes-app" content="app-id=357066198, affiliate-data=at=10lIEQ&ct=Web%20iPad%20Smart%20App%20Banner&pt=13036" />
+    <meta name="keywords" content="Hurricane Harvey (2017),Federal Emergency Management Agency,Beaumont (Tex),Houston (Tex),Hurricane Harvey (2017),Hurricanes and Tropical Storms,Weather,Houston (Tex),Beaumont (Tex),Harris County (Tex),Hurricane Harvey (2017),Texas,Floods,Hurricanes and Tropical Storms,Houston (Tex),Hurricane Harvey (2017),Floods,Deaths (Fatalities),Beaumont (Tex),Hurricane Harvey (2017),Deaths (Fatalities),Louisiana,Texas,Hurricane Harvey (2017),National Hurricane Center,Houston (Tex),Hurricane Harvey (2017),Area Planning and Renewal,Houston (Tex),Floods,New Orleans (La),Hurricane Harvey (2017),Corporate Taxes,Tax Credits, Deductions and Exemptions,Philanthropy,Houston (Tex),Hurricane Harvey (2017),Federal Aid (US),Federal Emergency Management Agency,Small Business Administration,Real Estate and Housing (Residential),Floods,Hurricane Harvey (2017),Humanitarian Aid,Frauds and Swindling,Hurricane Harvey (2017),Floods,Texas,Beaumont (Tex),port arthur texas,Floods,Hurricane Harvey (2017),Houston (Tex),Rain,Refineries,Hurricane Harvey (2017),Hurricanes and Tropical Storms,Evacuations and Evacuees,Texas,United States Politics and Government,Taxation,United States Economy,Springfield (Mo),Trump, Donald J,Tax Shelters,United States Economy,Corporate Taxes,Trump, Donald J,Republican Party,United States Politics and Government,Immigration Detention,Law and Legislation,Illegal Immigration,Trump, Donald J,Patient Protection and Affordable Care Act (2010),Health Insurance and Managed Care,State Children's Health Insurance Program (S-CHIP),United States International Relations,Extortion and Blackmail,Trump, Donald J,North Korea,Cohen, Michael D (1966- ),Russian Interference in 2016 US Elections and Ties to Trump Associates,House Committee on Intelligence,Trump, Donald J,Putin, Vladimir V,United States International Relations,Terrorism,United States Politics and Government,Afghanistan War (2001- ),United States Defense and Military Forces,Haqqani Network,Taliban,Trump, Donald J,Tillerson, Rex W,Pakistan,India,Leukemia,Immune System,Genetic Engineering,Cancer,Children's Hospital of Philadelphia,Food and Drug Administration,Novartis AG,University of Pennsylvania,June, Carl H,Whitehead, Emma,vis-multimedia,Accidents and Safety,Buildings (Structures),Mumbai (India),Tennis,United States Open (Tennis),Sharapova, Maria,Think Tanks,Google Inc,Alphabet Inc,New America Foundation,Schmidt, Eric E,Slaughter, Anne-Marie,Lynn, Barry,Open Markets,Computers and the Internet,Brazil,Amazon Jungle,Mines and Mining,Forests and Forestry,Indigenous People,Temer, Michel (1940- ),Zeid Ra'ad Zeid Al Hussein,Trump, Donald J,United Nations,News and News Media,Freedom of the Press,Newspapers,United States Politics and Government,Charlottesville, Va, Violence (August, 2017),United States Politics and Government,Afghanistan War (2001- ),United States Defense and Military Forces,Defense Department,Afghanistan,Exercise,Cooking and Cookbooks,Seasonal Affective Disorder (SAD),Sleep,Airlines and Airplanes,Comedy and Humor,Travel and Vacations,Monuments and Memorials (Structures),Politics and Government,de Blasio, Bill,Columbus, Christopher,New York City,David Tang,Deaths (Obituaries),Fashion and Apparel,Shanghai Tang,Entrepreneurship,London (England),Hong Kong,National Aeronautics and Space Administration,Space and Astronomy,Solar System,Exploration and Explorers,The Big Bang Theory (TV Program),Young Sheldon (TV Program),Television,Lorre, Chuck,Parsons, Jim,Social Media,Family Courts,Ethics and Official Misconduct,Administration for Children's Services (NYC),Legal Aid Society,Hansell, David,vis-multimedia,Australia,Same-Sex Marriage, Civil Unions and Domestic Partnerships,Political Advertising,Whales and Whaling,International Court of Justice (UN),Sea Shepherd Conservation Society,Antarctic Regions,Japan,Southern Ocean,Mathematics,Archaeology and Anthropology,Babylon (Iraq),Mansfield, Daniel F,Wildberger, Norman J,Historia Mathematica (Journal),Olympic Games,Olympic Games (1972),International Olympic Committee,Munich (Germany),Glasgow (Scotland),Great Britain,Travel and Vacations,Writing and Writers,Books and Literature,Ward, Jesmyn" />
+    <meta name="video:playerId" content="2640832222001" />
+    <meta name="video:publisherId" content="1749339200" />
+    <meta name="video:publisherReadToken" content="cE97ArV7TzqBzkmeRVVhJ8O6GWME2iG_bRvjBTlNb4o." />
+    <meta name="dfp-ad-unit-path" content="homepage/us" />
+    <meta name="dfp-amazon-enabled" content="false" />
+    <meta name="adxPage" content="homepage.nytimes.com/index.html" />
+
+    <link id="legacy-zam5nzz" rel="stylesheet" type="text/css" href="https://typeface.nyt.com/css/zam5nzz.css" media="all" />
+    <!--[if (gt IE 9)|!(IE)]> <!-->
+    <link rel="stylesheet" type="text/css" media="screen" href="https://a1.nyt.com/assets/homepage/20170810-135137/css/homepage/styles.css" />
+    <!--<![endif]-->
+    <!--[if lte IE 9]>
+    <link rel="stylesheet" type="text/css" media="screen" href="https://a1.nyt.com/assets/homepage/20170810-135137/css/homepage/styles-ie.css" />
+    <![endif]-->
+    <!--  begin abra  -->
+    <script>
+        var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=i[t];return n&&n[1]||null}function e(t,n){if(t){var e,o,r=n[0],i=n[1],u=0,c=0;if(1!==i.length||4294967296!==i[0])for(e=a(t+" "+r)>>>0,u=0,c=0;o=i[u++];)if(e<(c+=o[0]))return o}}function o(n,e,o,a){s+="subject="+n+"&test="+encodeURIComponent(e)+"&variant="+encodeURIComponent(o||0)+"&url="+encodeURIComponent(t.location.href)+"&instant=1&skipAugment=true\n",a&&f.push(a),c||(c=t.setTimeout(r,0))}function r(){var n=new t.XMLHttpRequest,e=f;n.withCredentials=!0,n.open("POST",u),n.onreadystatechange=function(){var t,o;if(4==n.readyState)for(t=200==n.status?null:new Error(n.statusText);o=e.shift();)o(t)},n.send(s),s="",f=[],c=null}function a(t){for(var n,e,o,r,a,i,u,c=0,s=0,f=[],l=[n=1732584193,e=4023233417,~n,~e,3285377520],h=[],p=t.length;s<=p;)h[s>>2]|=(s<p?t.charCodeAt(s):128)<<8*(3-s++%4);for(h[u=p+8>>2|15]=p<<3;c<=u;c+=16){for(n=l,s=0;s<80;n=[0|[(i=((t=n[0])<<5|t>>>27)+n[4]+(f[s]=s<16?~~h[c+s]:i<<1|i>>>31)+1518500249)+((e=n[1])&(o=n[2])|~e&(r=n[3])),a=i+(e^o^r)+341275144,i+(e&o|e&r|o&r)+882459459,a+1535694389][0|s++/20],t,e<<30|e>>>2,o,r])i=f[s-3]^f[s-8]^f[s-14]^f[s-16];for(s=5;s;)l[--s]=l[s]+n[s]|0}return l[0]}var i,u,c,s="",f=[];return n.init=function(n,r){var a,c,s,f,l,h=[],p=(t.document.cookie.match(/(^|;) *nyt-a=([^;]*)/)||[])[2],d=(t.document.cookie.match(/(^|;) *ab7=([^;]*)/)||[])[2],m=new RegExp("[?&]abra(=([^&#]*))"),g=m.exec(t.location.search);if(g&&g[2]&&(d=d?g[2]+"&"+d:g[2]),i)throw new Error("can't init twice");if(u=r,i={},d)for(d=decodeURIComponent(d).split("&"),a=0;a<d.length;a++)l=d[a].split("="),l[0]in i||(i[l[0]]=[,l[1],1],o("ab-alloc",l[0],l[1]),l[1]&&h.push(l[0]+"="+l[1]));for(a=0;a<n.length;a++)s=n[a],(c=s[0])in i||(f=e(p,s)||[],i[c]=f,f[1]&&h.push(c.replace(/[^\w-]/g)+"="+(""+f[1]).replace(/[^\w-]/g)),f[2]&&o("ab-alloc",c,f[1]));h.length&&t.document.documentElement.setAttribute("data-nyt-ab",h.join(" "))},n.reportExposure=function(n,e){var r=i[n];r&&r[2]?o("ab-expose",n,r[1],e):e&&t.setTimeout(function(){e(null)},0)},n}(this);
+    </script>
+    <script>NYTD.Abra.init([["HOME_ComingUp",[[2147483648,"control",1],[2147483648,"comingup",1]]],["HOME_NewsEvent2",[[3865470567,"full",1],[429496729,"control",1]]],["HOME_ElectionPrediction",[[3865470567,"on",1],[429496729,"control",1]]],["HOME_geoTrending",[[1460288881,"Control",1],[1417339208,"Header",1],[1417339207,"NoHeader",1]]],["www-ad-diagnostic",[[21474837,"1",0],[4273492459,null,0]]],["www-signup-favor-test",[[773094114,"0",1],[773094113,"1",1],[773094113,"2",1],[773094114,"3",1],[773094113,"4",1],[429496729,"5",1],[0,null,0]]],["www-readlater-test-1",[[1073741824,"control",1],[360777253,"controlHoldout",1],[1073741824,"variant1",1],[356482286,"variant1Holdout",1],[1073741824,"variant2",1],[356482285,"variant2Holdout",1]]],["www-signup-favor-test-v3",[[1288490189,"1",1],[1288490189,"2",1],[429496730,"4",1],[1288490188,"5",1]]],["www-signup-favor-test-v4",[[214748365,"control",1],[858993459,"1",1],[858993460,"2",1],[644245094,"4",1],[858993459,"5",1],[858993459,"6",1]]],["www-fabrik-off",[[4294967296,"1",1]]],["Liftoff",[[19520627,"0",1],[19520626,"1",1],[19520627,"2",1],[19520626,"3",1],[19520626,"4",1],[19520627,"5",1],[14839112,"0",1],[14839112,"1",1],[14839112,"2",1],[14839112,"3",1],[14839112,"4",1],[14839112,"5",1],[34359738,"8",1],[34359738,"9",1],[34359739,"12",1],[34359738,"13",1],[34359739,"16",1],[34359738,"17",1],[3882650435,null,0]]],["HP_AATest",[[2147483648,"0",1],[2147483648,"1",1]]],["EC_SampleTest",[[2147483648,"variantA",0],[2147483648,"variantB",0]]],["EC_DigiAbandonmentTest",[[4294967296,"sendAbandonmentEmail",1]]],["EC_HdAbandonmentTest",[[4294967296,"sendAbandonmentEmail",1]]],["EC_CrosswordsUpsellTest",[[2147483648,"control",1],[2147483648,"upsell",1]]],["EC_NewSubOnboardingTest",[[2147483648,"control",1],[2147483648,"sov1",1]]],["PaywallAU",[[429496730,"0",1],[3865470566,"1",1]]]], '//et.nytimes.com/')</script>
+    <!--  end abra  -->
+
+    <script>
+        (function () {
+            var e;
+            if (/^mobile\./.test(window.location.hostname)) {
+                var vi2 = (document.cookie.match(/(?:^|;) *vi=([^;]*)/) || [])[1] || '',
+                    vi1 = (document.cookie.match(/(?:^|;) *nyt\.np\.vi=([^;]*)/) || [])[1] || '';
+                e = /^b1/.test(vi2)   ? 'WP_ProjectVi&variant=vi'
+                    : /^z1/.test(vi2)   ? 'WP_ProjectVi&variant=0'
+                        : /^a2/.test(vi2)   ? 'WP_ProjectVi2&variant=hp-st'
+                            : /^b2/.test(vi2)   ? 'WP_ProjectVi2&variant=hp'
+                                : /^c2/.test(vi2)   ? 'WP_ProjectVi2&variant=st'
+                                    : /^z2/.test(vi2)   ? 'WP_ProjectVi2&variant=0'
+                                        : /^1\|/.test(vi1)  ? 'WP_ProjectVi&variant=vi'
+                                            : /^2\|/.test(vi1)  ? 'WP_ProjectVi&variant=0'
+                                                : '';
+            } else if (/^www\./.test(window.location.hostname)) {
+                var vi = (document.cookie.match(/(?:^|;) *vi_www_hp=([^;]*)/) || [])[1] || '';
+                e = /^a2/.test(vi)    ? 'WP_ProjectVi_www_hp&variant=hp-st'
+                    : /^b2/.test(vi)    ? 'WP_ProjectVi_www_hp&variant=hp'
+                        : /^c2/.test(vi)    ? 'WP_ProjectVi_www_hp&variant=st'
+                            : /^z2/.test(vi)    ? 'WP_ProjectVi_www_hp&variant=0'
+                                : '';
+            }
+            if (e) {
+                var x = new XMLHttpRequest();
+                x.withCredentials = true;
+                x.open('POST','//et.nytimes.com/');
+                x.send('subject=ab-alloc&test=' + e + '&url=' + encodeURIComponent(window.location.href) + '&instant=1&skipAugment=true\n');
+            }
+        })();
+    </script>
+    <script type="text/javascript">
+        document.addEventListener('DOMContentLoaded', function () {
+            if (!window.NYTD) {
+                window.NYTD = {};
+            }
+            window.NYTD.Global = {
+                displayBriefings: function (time) {
+                    var timedBriefings = document.getElementsByClassName('timedBriefing');
+                    if (!timedBriefings.length) {
+                        return;
+                    }
+                    var attrClass, attrStart, attrEnd, startTime, endTime;
+                    var reFormat = /^\d{2}:\d{2}$/;
+                    var reHide = / timedBriefingHide/i;
+
+                    for (var i = 0; i < timedBriefings.length; i++) {
+                        attrClass = timedBriefings[i].getAttribute('class');
+                        attrStart = timedBriefings[i].getAttribute('data-start-time');
+                        attrEnd = timedBriefings[i].getAttribute('data-end-time');
+                        if (attrStart && attrEnd && reFormat.test(attrStart) && reFormat.test(attrEnd)) {
+                            startTime = Number.parseInt(attrStart.replace(':', ''), 10);
+                            endTime = Number.parseInt(attrEnd.replace(':', ''), 10);
+
+                            // need to account for when the time span is across midnight
+                            if (startTime > endTime) {
+                                if (((time >= startTime) || (time < endTime)) && reHide.test(attrClass)) {
+                                    timedBriefings[i].setAttribute('class', attrClass.replace(reHide, ''));
+                                }
+                                if (((time < startTime) && (time >= endTime)) && !reHide.test(attrClass)) {
+                                    timedBriefings[i].setAttribute('class', (attrClass + ' timedBriefingHide'));
+                                }
+                            } else {
+                                if ((time >= startTime) && (time < endTime) && reHide.test(attrClass)) {
+                                    timedBriefings[i].setAttribute('class', attrClass.replace(reHide, ''));
+                                }
+                                if (((time < startTime) || (time >= endTime)) && !reHide.test(attrClass)) {
+                                    timedBriefings[i].setAttribute('class', (attrClass + ' timedBriefingHide'));
+                                }
+                            }
+                        }
+                    }
+                },
+                testTZ: function (offset) {
+                    var testTime = new Date(new Date().getTime() + (offset * 3600 * 1000));
+                    window.NYTD.Global.displayBriefings((testTime.getUTCHours() * 100) + testTime.getUTCMinutes());
+                    return testTime.toUTCString().replace(' GMT', '');
+                }
+            };
+            var now = new Date();
+            var previewTime = (now.getHours() * 100) + now.getMinutes();
+            var rePreviewTime = /previewTime=(\d*)/;
+            var matches = window.location.search.match(rePreviewTime);
+            if (matches) {
+                previewTime = Number.parseInt(matches[1]);
+            }
+            window.NYTD.Global.displayBriefings(previewTime);
+        });
+    </script>
+    <script type="text/javascript">var googletag=googletag||{};googletag.cmd=googletag.cmd||[],function(){var t=document.createElement("script");t.async=!0,t.type="text/javascript";var e="https:"==document.location.protocol;t.src=(e?"https:":"http:")+"//www.googletagservices.com/tag/js/gpt.js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(t,o)}();</script>
+    <script src="https://cdn.optimizely.com/public/3013110282/s/home_prod.js"></script>
+
+    <!--esi
+<script id="user-info-data" type="application/json">
+<esi:include src="/svc/web-products/userinfo-v3.json" />
+</script>
+-->
+    <script id="magnum-feature-flags" type="application/json">["limitFabrikSave","moreFollowSuggestions","unfollowComments","allTheEmphases","videoVHSCover","videoVHSHomepageCover","videoVHSHomepageNewControls","videoVHSNewControls","videoVHSEmbeddedOnly","additionalOpinionRegions","hpViewability","freeTrial","hpPrototype","useCollectionApiForWell","enableFlexFrameAds","weatherLocation","fabrikWebsocketsOnly","NYTExperiment","hpRealEstateAd","jitterbug","updatedVideoPromoSmall","videoEmbed360","PersonalizationApiUpdate","globalBriefings","removeInternationalEdition","clientSideABRA","abraOverrideVersion","signupFavor","mapleFreeTrial","piiBlockDFP","anchorsHttps","smarterLivingRec","viDesktopTest","caslOpt"]</script>
+    <script id="mpulse">
+        (function(){
+            if (window.BOOMR && window.BOOMR.version) { return; }
+            var dom,doc,where,iframe = document.createElement("iframe"),win = window;
+
+            function boomerangSaveLoadTime(e) {
+                win.BOOMR_onload=(e && e.timeStamp) || new Date().getTime();
+            }
+            if (win.addEventListener) {
+                win.addEventListener("load", boomerangSaveLoadTime, false);
+            } else if (win.attachEvent) {
+                win.attachEvent("onload", boomerangSaveLoadTime);
+            }
+
+            iframe.src = "javascript:void(0)";
+            iframe.title = ""; iframe.role = "presentation";
+            (iframe.frameElement || iframe).style.cssText = "width:0;height:0;border:0;display:none;";
+            where = document.getElementsByTagName("script")[0];
+            where.parentNode.insertBefore(iframe, where);
+
+            try {
+                doc = iframe.contentWindow.document;
+            } catch(e) {
+                dom = document.domain;
+                iframe.src="javascript:var d=document.open();d.domain='"+dom+"';void(0);";
+                doc = iframe.contentWindow.document;
+            }
+            doc.open()._l = function() {
+                var js = this.createElement("script");
+                if (dom) { this.domain = dom; }
+                js.id = "boomr-if-as";
+                js.src = "//c.go-mpulse.net/boomerang/" +
+                    "ATH8A-MAMN8-XPXCH-N5KAX-8D239";
+                BOOMR_lstart=new Date().getTime();
+                this.body.appendChild(js);
+            };
+            doc.write('<body onload="document._l();">');
+            doc.close();
+        })();
+    </script>
+    <script>
+        var require = {
+            baseUrl: 'https://a1.nyt.com/assets/',
+            waitSeconds: 20,
+            paths: {
+                'foundation': 'homepage/20170810-135137/js/foundation',
+                'shared': 'homepage/20170810-135137/js/shared',
+                'homepage': 'homepage/20170810-135137/js/homepage',
+                'application': 'homepage/20170810-135137/js/homepage/',
+                'videoFactory': 'https://static01.nyt.com/js2/build/video/2.0/videofactoryrequire',
+                'videoPlaylist': 'https://static01.nyt.com/js2/build/video/players/extended/2.0/appRequire',
+                'auth/mtr': 'https://static01.nyt.com/js/mtr',
+                'auth/growl': 'https://static01.nyt.com/js/auth/growl/default',
+                'vhs': 'https://static01.nyt.com/video/vhs/build/vhs-2.x.min',
+                'vhs3': 'https://static01.nyt.com/video-static/vhs3/vhs.min'
+            }
+        };
+    </script>
+    <!--[if (gte IE 9)|!(IE)]> <!-->
+    <script data-main="foundation/main" src="https://a1.nyt.com/assets/homepage/20170810-135137/js/foundation/lib/framework.js"></script>
+    <!--<![endif]-->
+    <!--[if lt IE 9]>
+    <script>
+        require.map = { '*': { 'foundation/main': 'foundation/legacy_main' } };
+    </script>
+    <script data-main="foundation/legacy_main" src="https://a1.nyt.com/assets/homepage/20170810-135137/js/foundation/lib/framework.js"></script>
+    <![endif]-->
+</head>
+<body>
+
+<style>
+    .lt-ie10 .messenger.suggestions {
+        display: block !important;
+        height: 50px;
+    }
+
+    .lt-ie10 .messenger.suggestions .message-bed {
+        background-color: #f8e9d2;
+        border-bottom: 1px solid #ccc;
+    }
+
+    .lt-ie10 .messenger.suggestions .message-container {
+        padding: 11px 18px 11px 30px;
+    }
+
+    .lt-ie10 .messenger.suggestions .action-link {
+        font-family: "nyt-franklin", arial, helvetica, sans-serif;
+        font-size: 10px;
+        font-weight: bold;
+        color: #a81817;
+        text-transform: uppercase;
+    }
+
+    .lt-ie10 .messenger.suggestions .alert-icon {
+        background: url('https://static01.nyt.com/images/icons/icon-alert-12x12-a81817.png') no-repeat;
+        width: 12px;
+        height: 12px;
+        display: inline-block;
+        margin-top: -2px;
+        float: none;
+    }
+
+    .lt-ie10 .masthead,
+    .lt-ie10 .navigation,
+    .lt-ie10 .comments-panel {
+        margin-top: 50px !important;
+    }
+
+    .lt-ie10 .ribbon {
+        margin-top: 97px !important;
+    }
+</style>
+<div id="suggestions" class="suggestions messenger nocontent robots-nocontent" style="display:none;">
+    <div class="message-bed">
+        <div class="message-container last-message-container">
+            <div class="message">
+                <span class="message-content">
+                    <i class="icon alert-icon"></i><span class="message-title">NYTimes.com no longer supports Internet Explorer 9 or earlier. Please upgrade your browser.</span>
+                    <a href="http://www.nytimes.com/content/help/site/ie9-support.html" class="action-link">LEARN MORE »</a>
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="shell" class="shell">
+    <header id="masthead" class="masthead theme-pinned-masthead" role="banner">
+
+        <div id="announcements-container" class="announcements-container"></div>
+
+        <div id="Header1" class="ad header1-ad"></div>
+
+        <div class="masthead-cap-container">
+
+            <div id="masthead-cap" class="masthead-cap">
+
+                <div class="quick-navigation button-group">
+
+                    <button class="button sections-button enable-a11y">
+                        <i class="icon sprite-icon"></i><span class="button-text">Sections</span>
+                    </button>
+                    <button class="button search-button">
+                        <i class="icon sprite-icon"></i><span class="button-text">Search</span>
+                    </button>
+                    <a class="button skip-button skip-to-content visually-hidden focusable" href="#top-news">Skip to content</a>
+                    <a class="button skip-button skip-to-navigation visually-hidden focusable" href="#site-index-navigation">Skip to navigation</a>
+                </div><!-- close quick-navigation -->
+
+                <div class="user-tools">
+
+                    <div id="Bar1" class="ad bar1-ad"></div>
+
+                    <div class="user-tools-button-group button-group">
+                        <button class="button subscribe-button hidden" data-href="https://www.nytimes.com/subscriptions/Multiproduct/lp3004.html?campaignId=4XUYF">Subscribe Now</button>
+                        <button class="button login-button hidden">Log In</button>
+                        <button class="button notifications-button hidden"><i class="icon sprite-icon"></i><span class="button-text">0</span></button>
+                        <button class="button user-settings-button">
+                            <i class="icon sprite-icon"></i><span class="button-text">Settings</span>
+                        </button>
+                    </div>
+
+                </div><!-- close user-tools -->
+
+            </div><!-- close masthead-cap -->
+
+        </div><!-- close masthead-cap-container -->
+
+        <div class="masthead-meta">
+            <div class="editions tab">
+
+                <ul class="editions-menu">
+                    <li class="edition-domestic-toggle active">English</li>
+                    <li class="edition-chinese-toggle"><a href="http://cn.nytimes.com" target="_blank" data-edition="chinese">中文 (Chinese)</a></li>
+                    <li class="edition-spanish-toggle"><a href="https://www.nytimes.com/es/" data-edition="spanish">Español</a></li>
+                </ul>
+
+            </div><!-- close editions -->
+
+            <div id="TopLeft" class="ad top-left-ad"></div>
+            <div id="TopRight" class="ad top-right-ad"></div>
+
+            <h2 class="branding"><a href="https://www.nytimes.com/">
+                <svg class="nyt-logo" width="379" height="64" role="img" aria-label="The New York Times">
+                    <image width="379" height="64" xlink:href="https://a1.nyt.com/assets/homepage/20170810-135137/images/foundation/logos/nyt-logo-379x64.svg" src="https://a1.nyt.com/assets/homepage/20170810-135137/images/foundation/logos/nyt-logo-379x64.png" alt="The New York Times" border="0"/>
+                </svg>
+
+            </a></h2>
+            <ul class="masthead-menu">
+                <li class="date">Thursday, August 31, 2017</li><li class="todays-paper"><a href="http://www.nytimes.com/pages/todayspaper/index.html" data-collection="todays-paper"><i class="icon sprite-icon"></i>Today’s Paper</a></li><li class="video"><a href="https://www.nytimes.com/video" data-collection="video"><i class="icon sprite-icon"></i>Video</a></li><li id="weather" class="weather hidden" data-collection="weather"><button class="button weather-button"></button></li><li id="markets" class="markets hidden" data-collection="markets"></li>
+            </ul>
+
+        </div><!-- close masthead-meta -->
+
+        <nav id="mini-navigation" class="mini-navigation">
+            <h2 class="visually-hidden">Quick Site Sections Navigation</h2>
+            <ul class="mini-navigation-menu">
+                <li>
+                    <button class="button sections-button">
+                        <i class="icon sprite-icon"></i>
+                        <span class="button-text">Sections</span>
+                    </button>
+                </li><li>
+                <button class="button search-button">
+                    <i class="icon sprite-icon"></i>
+                    <span class="button-text">Search</span>
+                </button>
+            </li>
+
+                <li class="shortcuts-9A43D8FC-F4CF-44D9-9B34-138D30468F8F ">
+                    <a href="https://www.nytimes.com/pages/world/index.html">World</a>
+                </li>
+
+
+                <li class="shortcuts-23FD6C8B-62D5-4CEA-A331-6C2A9A1223BE ">
+                    <a href="https://www.nytimes.com/pages/national/index.html">U.S.</a>
+                </li>
+
+
+                <li class="shortcuts-80E6DEE6-87E4-4AD0-9152-14FA6B07E5AB ">
+                    <a href="https://www.nytimes.com/pages/politics/index.html">Politics</a>
+                </li>
+
+
+                <li class="shortcuts-C4DC8C0C-E148-4201-BF10-82F1C903DBFB ">
+                    <a href="https://www.nytimes.com/pages/nyregion/index.html">N.Y.</a>
+                </li>
+
+
+                <li class="shortcuts-104D1E63-9701-497B-8CF4-A4D120C9014E domestic">
+                    <a href="https://www.nytimes.com/pages/business/index.html">Business</a>
+                </li>
+
+
+                <li class="shortcuts-A257D89A-0D3C-40AF-9C34-1A25A7947D94 international">
+                    <a href="https://www.nytimes.com/pages/business/international/index.html">Business</a>
+                </li>
+
+
+                <li class="shortcuts-AD8090D7-4137-4D71-84C8-70DA3BD89778 domestic">
+                    <a href="https://www.nytimes.com/pages/opinion/index.html">Opinion</a>
+                </li>
+
+
+                <li class="shortcuts-09736473-CB3F-4B2F-9772-3AF128ABE12D international">
+                    <a href="https://www.nytimes.com/pages/opinion/international/index.html">Opinion</a>
+                </li>
+
+
+                <li class="shortcuts-78FBAD45-31A9-4EC7-B172-7D62A2B9955E ">
+                    <a href="https://www.nytimes.com/pages/technology/index.html">Tech</a>
+                </li>
+
+
+                <li class="shortcuts-A4B35924-DB6C-4EA3-997D-450810F4FEE6 ">
+                    <a href="https://www.nytimes.com/section/science">Science</a>
+                </li>
+
+
+                <li class="shortcuts-7D6BE1AF-8CD8-430B-8B2A-17CD0EAA99AC ">
+                    <a href="https://www.nytimes.com/pages/health/index.html">Health</a>
+                </li>
+
+
+                <li class="shortcuts-DE2B278B-2783-4506-AAD5-C15A5BB6DA1A domestic">
+                    <a href="https://www.nytimes.com/pages/sports/index.html">Sports</a>
+                </li>
+
+
+                <li class="shortcuts-BE66F420-C51B-461D-B487-CACF62E94AAE international">
+                    <a href="https://www.nytimes.com/pages/sports/international/index.html">Sports</a>
+                </li>
+
+
+                <li class="shortcuts-C5BFA7D5-359C-427B-90E6-6B7245A6CDD8 domestic">
+                    <a href="https://www.nytimes.com/pages/arts/index.html">Arts</a>
+                </li>
+
+
+                <li class="shortcuts-0202D0E4-C59B-479A-BD42-6F1766459781 international">
+                    <a href="https://www.nytimes.com/pages/arts/international/index.html">Arts</a>
+                </li>
+
+
+                <li class="shortcuts-B3DFBD82-F298-43B3-9458-219B4F6AA2A5 domestic">
+                    <a href="https://www.nytimes.com/pages/fashion/index.html">Style</a>
+                </li>
+
+
+                <li class="shortcuts-CC9E2674-F6C4-4A39-813B-F5AB0C515CEA international">
+                    <a href="https://www.nytimes.com/pages/style/international/index.html">Style</a>
+                </li>
+
+
+                <li class="shortcuts-D9C94A2B-0364-4D25-8383-592CC66F82D4 domestic">
+                    <a href="https://www.nytimes.com/pages/dining/index.html">Food</a>
+                </li>
+
+
+                <li class="shortcuts-FDEFB811-B483-4C3D-A25A-FD07BE5EAD96 international">
+                    <a href="https://www.nytimes.com/pages/dining/international/index.html">Food</a>
+                </li>
+
+
+                <li class="shortcuts-FDA10AC4-4738-4099-91E8-15584765C8D7 ">
+                    <a href="https://www.nytimes.com/section/travel">Travel</a>
+                </li>
+
+
+                <li class="shortcuts-E57A148E-0CB9-4C02-966D-28B119710151 ">
+                    <a href="https://www.nytimes.com/pages/magazine/index.html">Magazine</a>
+                </li>
+
+
+                <li class="shortcuts-052C33AD-1404-4DB6-AA70-0901DB1AD95B ">
+                    <a href="https://www.nytimes.com/section/t-magazine">T Magazine</a>
+                </li>
+
+
+                <li class="shortcuts-92720057-BCB6-4BDB-9351-12F29393259F ">
+                    <a href="https://www.nytimes.com/section/realestate">Real Estate</a>
+                </li>
+
+                <li><button class="button all-sections-button">all</button></li>
+            </ul>
+        </nav>
+        <div class="search-flyout-panel flyout-panel">
+            <button class="button close-button" type="button"><i class="icon"></i><span class="visually-hidden">Close search</span></button>
+            <nav class="search-form-control form-control layout-horizontal">
+                <h2 class="visually-hidden">Site Search Navigation</h2>
+                <form class="search-form" role="search">
+                    <div class="control">
+                        <div class="label-container visually-hidden">
+                            <label for="search-input">Search NYTimes.com</label>
+                        </div>
+                        <div class="field-container">
+                            <input id="search-input" name="search-input" type="text" class="search-input text" autocomplete="off" placeholder="Search NYTimes.com" />
+
+                            <button type="button" class="button clear-button" tabindex="-1" aria-describedby="clear-search-input"><i class="icon"></i><span id="clear-search-input" class="visually-hidden">Clear this text input</span></button>
+                            <div class="auto-suggest" style="display: none;">
+                                <ol></ol>
+                            </div>
+                            <button class="button submit-button" type="submit">Go</button>
+                        </div>
+                    </div><!-- close control -->
+                </form>
+            </nav>
+
+
+        </div><!-- close flyout-panel -->
+        <div id="notification-modals" class="notification-modals"></div>
+
+    </header><!-- close masthead -->
+    <div id="masthead-placeholder" class="masthead-placeholder"></div>
+    <nav id="navigation" class="navigation">
+        <h2 class="visually-hidden">Site Navigation</h2>
+    </nav><!-- close navigation -->
+
+    <nav id="mobile-navigation" class="mobile-navigation hidden">
+        <h2 class="visually-hidden">Site Mobile Navigation</h2>
+    </nav><!-- close mobile-navigation -->
+
+    <div id="navigation-edge" class="navigation-edge"></div>
+    <div id="page" class="page">
+        <main id="main" class="main" role="main">
+            <div id="Top" class="ad hp-top-ad nocontent nojitter robots-nocontent"></div>
+            <div id="Top_Close" class="ad hp-top-ad-close hidden nocontent robots-nocontent"></div>
+            <div id="Top5" class="ad top5-ad hidden nocontent robots-nocontent"></div>
+
+            <div class="span-abc-region region">
+                <div class="collection">
+                    <script type="text/javascript">
+                        /*! geoip_resolver 2016-06-30 */
+                        +function(a){"function"==typeof define&&define.amd?define("nytint-geoip",[],a):window.nytint_geoip=a()}(function(){"use strict";var a="nyt-geoip",b=document.getElementsByTagName("html"),c=!1,d=["continent_code","country_code","region","dma_code","postal_code","time_zone","zone_abbr"],e=function(b){var c=new XMLHttpRequest,d=null,e=null;try{if(d=JSON.parse(sessionStorage.getItem(a)),d&&void 0!==d.country_code)return g(d,b),d}catch(h){}c.onload=function(a){return a.target?(e=f(a.target),"undefined"==typeof e?!1:(g(e,b),e)):!1},c.onreadystatechange=function(){4===c.readyState&&200!==c.status&&console.error(c.status)},c.open("GET","https://geoip.newsdev.nytimes.com/",!0);try{c.responseType="json"}catch(h){}c.send()},f=function(a){var b=null;switch(!0){case"json"===a.responseType:b=a.response.data;break;case null!==a.response:b=JSON.parse(a.response).data;break;case null!==a.responseText:b=JSON.parse(a.responseText).message}return void 0!==b?b:null},g=function(e,f){if(!b)return!1;try{sessionStorage.setItem(a,JSON.stringify(e))}catch(g){}if(void 0!==e&&!c){for(var i,j=0;i=d[j];j++)if(void 0!==e[i]){var k=["geo",h(i),e[i]].join("-");b[0].classList.add(k)}c=!0}return"function"==typeof f&&f(e),e},h=function(a){var b=a;switch(!0){case a.indexOf("zone_abbr")>=0:b=a.replace("zone_abbr","us-timezone");break;case a.indexOf("_zone")>=0:b=a.replace("_zone","zone");break;case a.indexOf("_code")>=0:b=a.replace("_code","")}return b};return window.NYTINT_TESTING||e(),e});
+                        (function() { require(['nytint-geoip']); })();
+                    </script><!-- HP CSS Fixes -->
+                    <style>
+
+                        /* Fix for Small Video Promo Heds */
+                        .story.theme-feature.video-promo-small.updated-video-promo-small .video-promo-small-container .story-heading{ padding: 0!important; }
+
+
+                        /* Fix MM icons in kickers */
+                        .kicker .icon:before { top: 0px; }
+                        .kicker .media.slideshow { margin-bottom: 0px; }
+
+                        /* Hiding Hacks */
+
+                        .nythpHideKickers .kicker, .nythpHideBylines .byline, .nythpHideTimestamps .timestamp {
+                            display: none;
+                        }
+
+                        /* banner hed modifications */
+                        .span-ab-top-region .story.theme-summary .story-heading {
+                            line-height: 2.1rem;
+                        }
+
+                        /* spacing fixes */
+                        .collection.headlines {
+                            margin-bottom: 12px;
+                        }
+
+
+                        /* Alterations to the Centered Feature Photo Spot Treatment */
+
+                        .b-column .photo-spot-region .story.theme-feature .story-heading {
+                            font-size: 1.35rem;
+                            line-height: 1.65rem;
+                        }
+
+                        .b-column  .photo-spot-region .story.theme-feature .story-heading {
+                            padding: 0 22px; /* for headline wrapping  */
+                        }
+                        .b-column .photo-spot-region .story.theme-feature .summary {
+                            line-height: 18px;
+                        }
+
+                        .story.theme-feature .summary {
+                            line-height: 1.125rem;
+                            color: #333;
+                            margin: 0 10px 3px;
+                        }
+
+
+
+
+                        /* Bullet Treatments */
+
+                        .ab-column .collection article ul, .span-abc-region .collection article ul {
+                            margin-top: 8px;
+                            margin-bottom: -3px;
+                        }
+
+                        .ab-column .collection article ul.refer, .span-abc-region .collection article ul.refer {
+                            margin-top: 2px;
+                            margin-bottom: 0px;
+                        }
+
+                        .ab-column .collection article ul li, .span-abc-region .collection article ul li {
+                            position: relative;
+                            margin-bottom: 8px;
+                            padding-left: 9px;
+                            font-size: 13px;
+                            font-size: 0.8125rem;
+                            line-height: 18px;
+                            line-height: 1.125rem;
+                            font-weight: 400;
+                        }
+                        .ab-column .collection article ul li:before, .span-abc-region .collection article ul li:before {
+                            border-radius: 1px;
+                            background-color: #000;
+                            width: 3px;
+                            height: 3px;
+                            content: '';
+                            position: absolute;
+                            display: block;
+                            top: 7px;
+                            left: 2px;
+                        }
+
+                        .ab-column .collection article ul li:last-child, .span-abc-region .collection article ul li:last-child {
+                            margin-bottom: 0=;
+                        }
+
+                        .ab-column .collection article[data-collection-renderstyle="HpSumMediumMedia"] ul {
+                            margin-bottom: 0px;
+                        }
+
+                        .theme-news-headlines li {
+                            position: relative!important;
+                            margin-bottom: 4px!important;
+                            padding-left: 8px!important;
+                        }
+                        .theme-news-headlines {
+                            margin-top: 2px!important;
+                        }
+
+                        .a-column .story.theme-summary.headline-medium-summary .medium-thumb {
+                            float: none;
+                            clear: none;
+                            margin-left: 0px;
+                        }
+
+                        .first-column-region .story.theme-summary.headline-medium-summary .story-heading, .a-lede-package-region .story.theme-summary.headline-medium-summary .story-heading {
+                            font-style: italic;
+                        }
+
+                        .first-column-region .collection:first-child .story.theme-summary.headline-medium-summary .story-heading, .a-lede-package-region .collection:first-child .story.theme-summary.headline-medium-summary .story-heading {
+                            font-size: 26px;
+                            font-size: 1.625rem;
+                            line-height: 28px;
+                            line-height: 1.75rem;
+                            font-weight: 700;
+                        }
+
+
+                        /* Breaking News/Developing Headers */
+                        .nythpBreaking {
+                            color: #A81817;
+                            border-top: 3px solid #A81817;
+                            padding-top: 2px;
+                            padding-bottom: 3px;
+                            margin-top: 12px;
+                        }
+
+                        .nythpBreaking h6 {
+                            text-transform: uppercase;
+                            font-family: "nyt-franklin",arial,helvetica,sans-serif;
+                            font-weight: 700;
+                        }
+
+                        .nythpDeveloping {
+                            color: #FD8249;
+                            border-top-color: #FD8249;
+                        }
+
+                        .nythpBreaking.nythpNoRule {
+                            border: none;
+                            margin-top: 0px;
+                        }
+
+                        .above-banner-region .nythpBreaking {
+                            margin-bottom: 10px;
+                        }
+
+
+                        /* BEGIN .HPHEADER STYLING */
+
+                        .hpHeader, .span-abc-region h3.collection-kicker {
+                            margin-bottom: 10px;
+                        }
+
+                        .hpHeader h6, .span-abc-region h3.collection-kicker {
+                            color: #000;
+                            font-family: "nyt-franklin",helvetica,arial,sans-serif;
+                            text-transform: uppercase;
+                            font-size: 12px;
+                            font-weight: 700;
+                            letter-spacing: .5px;
+                            border-bottom: 2px solid #ccc;
+                            display: inline-block;
+                            line-height: 15px;
+                        }
+
+                        .span-abc-region h6, .span-abc-region h3.collection-kicker {
+                            font-size: 13px;
+                            line-height: 16px;
+
+                        }
+
+                        .hpHeader h6 a, .span-abc-region h3.collection-kicker a,
+                        .hpHeader h6 a:visited, .span-abc-region h3.collection-kicker a:visited  {
+                            text-decoration: none;
+                            color: #000;
+                        }
+
+                        .hpHeader h6:hover,
+                        .hpHeader h6:active {
+                            border-color: #222222;
+                        }
+
+                        .above-banner-region .hpHeader, .span-ab-top-region .hpHeader, .span-ab-lede-package-region .hpHeader, .b-column .hpHeader, .c-column .hpHeader  {
+                            text-align: center;
+                        }
+
+                        .above-banner-region .hpHeader h6, .span-ab-top-region .hpHeader h6, .span-ab-lede-package-region .hpHeader h6, .b-column .hpHeader h6, .c-column .hpHeader h6  {
+                            margin: 0 auto;
+                            padding: 0 2px;
+                        }
+
+                        .span-ab-top-region .a-column .hpHeader, .span-ab-lede-package-region .a-column .hpHeader, .b-column .split-layout .hpHeader, .b-column .nythpSplitCode .hpHeader {
+                            text-align: left;
+                        }
+
+                        .b-column .split-layout .hpHeader h6, .b-column .nythpSplitCode .hpHeader h6 {
+                            margin: 0;
+                            padding: 0;
+                        }
+
+                        .hpLive h6, .hpLive h6:hover, .hpLive h6:active {
+                            color: #a81817;
+                            border-color: #a81817;
+                        }
+
+                        .hpDeveloping h6, .hpDeveloping h6:hover, .hpDeveloping h6:active  {
+                            color: #fd8249;
+                            border-color: #fd8249;
+                        }
+
+                        .hpSingleRule {
+                            border-top: 1px solid #e2e2e2;
+                            padding-top: 12px;
+                        }
+
+
+
+                        /* added by matte to fix slideshow bug */
+
+                        .loader-container {
+                            display: none;
+                        }
+
+                        /* Newsletter Sign-Up Modules (updated 6/28/2017) */
+
+                        div.notification-widget {
+                            min-height:38px;
+                        }
+                        .notification-signup .notifications-title {
+                            color: black;
+                            font-family: "nyt-cheltenham-sh",georgia,"times new roman",times,serif;
+                            font-size: 15px;
+                            line-height: 18px;
+                            font-weight: 200;
+                        }
+                        .notification-signup .notification-text {
+                            margin-top: 3px;
+                            margin-bottom: 5px;
+                            color: #999;
+                            font-size: 13px;
+                            line-height: 18px;
+                        }
+
+                        .notification-widget input,
+                        .notification-widget button {
+                            outline: none;
+                        }
+
+                        .notification-widget .notify-email {
+                            height: 30px;
+                            width: 312px;
+                            margin-top: 0px;
+                            padding: 14px;
+                            color: #a6a6a6;
+                            border: 1px solid rgba(97,136,166,.5);
+                            border-top-left-radius: 2px;
+                            border-bottom-left-radius: 2px;
+                            border-top-right-radius: 0px;
+                            border-bottom-right-radius: 0px;
+                            box-shadow: none;
+                            font-family: 'nyt-franklin', Helvetica, sans-serif;
+                            font-size: 14px;
+                            line-height: 1;
+                        }
+                        .notification-widget .notify-email:hover{
+                            border-color:rgba(97,136,166,1);
+                            border-width:2px;
+                            padding:13px;
+                        }
+                        .notification-widget .notify-email.error {
+                            border-color: #FF9859;
+                        }
+                        .notification-widget .button {
+                            margin-top: 0px;
+                            padding: 8px;
+                            border: none;
+                            border-top-left-radius: 0px;
+                            border-bottom-left-radius: 0px;
+                            border-top-right-radius: 2px;
+                            border-bottom-right-radius: 2px;
+                            background: #6288a5;
+                            color: white;
+                            font-family: 'nyt-franklin', Helvetica, sans-serif;
+                            font-size: 14px;
+                            font-weight: 500;
+                            line-height: 1;
+                            text-transform: capitalize;
+                        }
+
+                        .notification-widget .dirtyform .button:hover,
+                        .notification-widget .signedin .button:hover {
+                            background-color: #326891;
+                        }
+
+                        .notification-widget .signedin .button {
+                            border-top-left-radius: 2px;
+                            border-bottom-left-radius: 2px;
+                        }
+
+                        .notification-widget div.error {
+                            font-family: 'nyt-franklin', Helvetica, sans-serif;
+                            color: #FF9859;
+                            font-size: 12px;
+                            margin-top: 5px;
+                        }
+
+                        /* post subscribe notification */
+                        .notification-signup span {
+                            font-size: 14px;
+                            color: ##ffffff;
+                            font-family: 'nyt-franklin', Helvetica, sans-serif;
+                            font-weight: 600;
+                        }
+                        .notification-widget div[data-status="initial"]{
+                            display:inline-block;
+                            float:right;
+                        }
+
+                        .notification-widget div[data-status="working"]{
+                            opacity:0;
+                        }
+
+                        /* already subscribed notification */
+                        .notification-widget div[data-status="initial"] div,
+                        .notification-widget div[data-status="subscribed"] div,
+                        .notification-widget div[data-status="working"] div {
+                            font-family: 'nyt-franklin', Helvetica, sans-serif;
+                            font-size: 14px;
+                            color: #666 !important;
+                        }
+                        .notification-widget div[data-status="initial"] div{
+                            line-height: 31px;
+                        }
+                        .notification-widget div[data-status="initial"] div div{
+                            margin-right:8px;
+                            display:inline-block;
+                        }
+
+                        .notification-widget div[data-status="initial"] div .account-name,
+                        .notification-widget div[data-status="subscribed"] div .account-name{
+                            font-weight: 700;
+                        }
+                        .notification-signup a {
+                            font-size: 14px;
+                            font-family: 'nyt-franklin', Helvetica, sans-serif;
+                            font-weight: 400;
+                            margin-top: 10px;
+                            display: block;
+                            color: #6187a6!important;
+                        }
+                        .notification-widget .email-address a{
+                            margin-top: 5px;
+                            display: block;
+                            color: #6187a6!important;
+                        }
+                        .viewport-medium-10 .interactive-leadin, .viewport-medium-10 .notification-signup .notification-text{
+                            max-width: 375px;
+                        }
+                        .notification-signup{
+                            padding-top:11px;
+                        }
+
+                        a[data-reactid=".0.0.2"] {
+                            font-size: 11px; }
+
+                        .notification-widget div[data-status="initial"][data-show-disclaimer="true"] div.disclaimer {
+                            display: none;
+                            color: #CCC !important;
+                            font-size: 14px;
+                        }
+
+                        .notification-widget div.signedin[data-status="initial"][data-show-disclaimer="true"] div.disclaimer {
+                            top: -20px;
+                            right: 14px;
+                            position: relative;
+                            height: 8px;
+                            display: block;
+                        }
+
+                        .notification-widget div.not-signedin[data-status="initial"][data-show-disclaimer="true"] div.disclaimer {
+                            display: block;
+                            text-align: right;
+                        }
+
+
+                        .notification-widget div[data-status="initial"][data-show-disclaimer="true"] div.disclaimer a {
+                            color: #CCC !important;
+                            text-decoration: underline;
+                        }
+
+                        .notification-widget div[data-status="initial"][data-show-disclaimer="true"] div.welcome {
+                            position: relative;
+                            top: -5px;
+                            color: #999 !important;
+                        }
+
+
+                        /* Show All hack */
+                        html.showAllGeoAb .timedBriefingHide, html.showAllGeoAb .nythpElectionPredictionCCol, html.showAllGeoAb .nythpNYRegionPromo, html.showAllGeoAb .nythpGeoCanada, html.showAllGeoAb .nythpCAToday { display: block !important }
+
+
+                    </style>
+
+
+
+
+                    <!-- Begin Smarter Living Styles and Scripts -->
+
+                    <script type="text/javascript">
+                        require(['foundation/main'], function () {
+                            require([
+                                'jquery/nyt',
+                                'foundation/helpers/utils',
+                                'foundation/views/page-manager'
+                            ], function ($, utils, pageManager) {
+                                $(document).ready(function () {
+                                    var param = {
+                                        'contentCollection': 'smarter-living'
+                                    };
+                                    $('.nythpSmarterLiving a').each(function () {
+                                        var href = $(this).attr('href');
+                                        href = utils.appendQueryParams(href, param);
+                                        $(this).attr('href', href);
+                                    });
+                                });
+                            });
+                        });
+                    </script>
+                    <style>
+
+                        .nythpSmarterLiving {
+                            zoom:1;
+                            border-bottom: 0px solid #e2e2e2;
+                            margin-bottom: 12px;
+                        }
+
+                        .nythpSmarterLiving:after,
+                        .nythpSmarterLiving:before {
+                            content: "";
+                            display: table;
+                        }
+                        .nythpSmarterLiving:after{
+                            clear: both;
+                        }
+                        .nythpSmarterLiving article {
+                            float:left;
+                            width: 177px;
+                        }
+                        .nythpSmarterLiving article.story.theme-summary {
+                            margin-bottom: 0px;
+                        }
+
+                        .nythpSmarterLiving article:last-child,
+                        .nythpSmarterLiving article:nth-of-type(2) {
+                            margin-left: 21px;
+                        }
+
+                        .nythpSmarterLiving .byline, .nythpSmarterLiving .summary, .nythpSmarterLiving article .kicker, .nythpSmarterLiving .theme-comments, .nythpSmarterLiving .refer {
+                            display: none;
+                        }
+
+                        .nythpSmarterLiving .story.theme-summary .story-heading {
+                            width: 96px;
+                            float: right;
+                        }
+
+                        .nythpSmarterLiving .story.theme-summary .thumb {
+                            margin: 3px 6px 6px 0px;
+                            float: left;
+                            clear: none;
+                        }
+
+
+                    </style></div>
+                <div class="collection">
+                    <style type="text/css">
+                        .span-abc-region .story.theme-summary h1.story-heading {
+                            font-size: 38px;
+                            font-style: italic;
+                            line-height: 44px;
+                            margin-bottom: 10px;
+                            margin-top:-8px;
+                            font-family: "nyt-cheltenham",georgia,"times new roman",times,serif;
+                        }
+
+                        .span-abc-region .nythpParisMega1stCol article[data-collection-renderstyle="LedeSum"].story.theme-summary h2.story-heading {
+                            font-size: 1.625rem;
+                            line-height: 1.75rem;
+                            font-weight: 700;
+                            font-style: italic;
+                            font-family: "nyt-cheltenham",georgia,"times new roman",times,serif;
+                            letter-spacing: 0.01em;
+                            word-spacing: -0.1em;
+                        }
+
+                        .span-abc-region .nythpParisMega1stCol .story.theme-summary h2.story-heading {
+                            font-size: 20px;
+                            font-size: 1.25rem;
+                            line-height: 22px;
+                            line-height: 1.375rem;
+                            font-weight: 700;
+                            font-style: normal;
+                            font-family: "nyt-cheltenham",georgia,"times new roman",times,serif;
+                            letter-spacing: 0.01em;
+                            word-spacing: -0.1em;
+                        }
+
+                        .span-abc-region .nythpSpanABCMiddleColumn .nytHPSplit-AB-Half .story.theme-summary h2.story-heading {
+                            font-size: 16px;
+                            font-size: 1rem;
+                            line-height: 22px;
+                            line-height: 1.375rem;
+                            font-weight: 700;
+                            font-style: normal;
+                            font-family: "nyt-cheltenham",georgia,"times new roman",times,serif;
+                            letter-spacing: 0.01em;
+                            word-spacing: -0.1em;
+                        }
+
+
+                        .span-abc-region .nythpSpanABCMiddleColumn .nytHPSplit-AB-Half .story.theme-summary .thumb {
+                            margin-top:-20px;
+                        }
+
+
+
+
+                    </style><!--FOR ALL CAPS-->
+                    <style>
+                        .span-ab-top-region .story.theme-summary h1.story-heading{
+                            line-height:45px;
+                            margin-top:2px;
+                        }
+                    </style>
+
+                    <div class="span-ab-top-region"><article class="story theme-summary banner" data-collection-renderstyle="Banner"><h1 class="story-heading">
+
+                        <!-- Link and Hed Go Here -->
+                        <a href="https://www.nytimes.com/2017/08/30/us/small-towns-harvey.html">The Storm Marches On as Houston Surveys Wreckage
+                        </a>
+
+
+
+
+                        <span class="product-label theme-nyt-now" style="display:none;"><span class="visually-hidden">NYT Now</span><i class="icon dot-logo-icon"></i></span></h1></article></div></div>
+                <div class="collection">
+                    <style>
+                        .nythpSplitCode .column { margin-left: 21px; }
+                        .nythpSplitCode .column:first-child { margin-left: 0px; }
+                        .nythpSplitCode.layout { background: none; }
+                        .nythpSplitCode .media.photo.medium-thumb { float: none; margin-left: 0; }
+                        .nythpSpanABCMiddleColumn {width: 573px; float: right;}
+                        .nythpSplitCode .nythpSpanABC_ABCol {width: 771px; float: left;}
+                        .nythpSplitCode .nythpSpanABC_SpanABBottom {clear: both;}
+                        <!--.nythpParisMegaBanner {} -->
+                    </style>
+
+                    <div class="layout nythpSplitCode nythpParisMega">
+                        <div class="nythpSpanABC_ABCol">
+                            <div class="column nythpParisMega1stCol"><div>
+
+                            </div>
+                                <div class="collection">
+                                    <article class="story theme-summary" id="topnews-100000005401006" data-story-id="100000005401006" data-rank="0" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                        <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/us/small-towns-harvey.html">Hundreds of Towns in Harvey’s Path Hit by Devastating Rain</a></h2>
+
+                                        <p class="byline">By CAMPBELL ROBERTSON, RICK ROJAS and SHAILA DEWAN </p>
+
+                                        <p class="summary"><ul> <li>Harvey, downgraded to a tropical depression, moved to the east and punished a region of roughly 11 million people.
+                                    </li>
+                                        <li>In Houston, after the first night of a citywide curfew, many residents went outside for the first time in days to survey the wreckage. Officials have reported at least 38 deaths.
+                                        </li>
+                                    </ul></p>
+
+
+                                    </article>
+                                </div>
+                                <div class="collection">
+                                    <article class="story theme-summary" id="topnews-100000005399284" data-story-id="100000005399284" data-rank="0" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                        <h3 class="kicker"><span class="timestamp"><strong>Live</strong></span> </h3>
+                                        <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/us/hurricane-harvey-flooding-houston.html">Explosions Reported at Chemical Plant</a></h2>
+
+                                        <p class="byline">By THE NEW YORK TIMES <time class="timestamp" datetime="2017-08-31" data-eastern-timestamp="6:47 AM" data-utc-timestamp="1504176457">6:47 AM ET</time></p>
+
+                                        <p class="summary">Two explosions were reported at a chemical plant about 30 miles from Houston that was damaged by Hurricane Harvey.</p>
+
+                                        <p class="theme-comments">
+                                            <a href="https://www.nytimes.com/2017/08/30/us/hurricane-harvey-flooding-houston.html?hp&amp;target=comments#commentsContainer" class="comments-link"><i class="icon sprite-icon comments-icon"></i><span class="comment-count">&nbsp;Comments</span></a>
+                                        </p>
+
+                                    </article>
+                                </div>
+                                <div class="collection">
+                                    <style>
+                                        .first-column-region .nythpMakeAColHedLikeB .story.theme-summary .story-heading,
+                                        .a-lede-package-region .nythpMakeAColHedLikeB .story.theme-summary .story-heading,
+                                        .span-abc-region .nythpParisMega1stCol .nythpMakeAColHedLikeB .story.theme-summary h2.story-heading {
+                                            font-size: 14px;
+                                            font-size: 0.875rem;
+                                            line-height: 16px;
+                                            line-height: 1rem;
+                                            font-weight: 700;
+                                            font-style: normal;
+                                            font-family: "nyt-cheltenham-sh",georgia,"times new roman",times,serif;
+                                            margin-bottom: 2px;
+                                        }
+                                    </style>
+
+                                    <div class="nythpMakeAColHedLikeB"><article class="story theme-summary" id="topnews-100000005395157" data-story-id="100000005395157" data-rank="1" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                        <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/28/us/hurricane-harvey-texas.html">A Guide to the Storm</a></h2>
+
+
+                                        <p class="summary">Here’s an overview of coverage by The New York Times.</p>
+
+
+                                    </article>
+                                    </div></div>
+                                <div class="collection">
+                                </div></div>
+                            <div class="column nythpSpanABCMiddleColumn"><div></div>
+                                <div class="collection">
+                                    <!--
+
+======================================================
+
+THIS IS A GENERATED TEMPLATE FILE. DO NOT EDIT.
+
+======================================================
+
+-->
+                                    <!-- hp promo -->
+
+                                    <!-- this file is generated from src/style.less -->
+                                    <style>/*
+  SHOW LIBRARY
+  ===================== */
+                                    .g-show-xsmall,
+                                    .g-show-small,
+                                    .g-show-smallplus,
+                                    .g-show-submedium,
+                                    .g-show-sub-medium,
+                                    .g-show-medium,
+                                    .g-show-large,
+                                    .g-show-xlarge {
+                                        display: none;
+                                    }
+                                    .g-show {
+                                        display: block;
+                                    }
+                                    .lt-ie10 .g-aiImg {
+                                        width: 100%;
+                                    }
+                                    /* story top */
+                                    .story.theme-main .story-header .story-meta .story-heading {
+                                        max-width: 720px;
+                                        margin: 0 auto 10px;
+                                        text-align: center;
+                                        line-height: 2.844rem;
+                                        font-size: 2.4rem;
+                                    }
+                                    @media only screen and (max-width: 1244px) {
+                                        .story.theme-main .story-header .story-meta .story-heading {
+                                            line-height: 2.5596rem;
+                                            font-size: 2.16rem;
+                                        }
+                                    }
+                                    @media only screen and (max-width: 719px) {
+                                        .story.theme-main .story-header .story-meta .story-heading {
+                                            line-height: 2.2752rem;
+                                            font-size: 1.92rem;
+                                        }
+                                    }
+                                    .story.theme-main .story-header .story-meta .interactive-leadin.summary {
+                                        max-width: 460px;
+                                        margin: 0 auto 20px auto;
+                                        text-align: center;
+                                        font-size: 17px;
+                                        line-height: 1.6;
+                                    }
+                                    .story.theme-main .story-header .story-meta .byline-dateline {
+                                        text-align: center;
+                                    }
+                                    /* top asset */
+                                    .g-top-asset {
+                                        margin-left: auto;
+                                        margin-right: auto;
+                                        margin-bottom: 20px;
+                                    }
+                                    .g-top-asset img {
+                                        width: 100%;
+                                    }
+                                    /* body text */
+                                    .g-body {
+                                        max-width: 460px;
+                                        margin-left: auto;
+                                        margin-right: auto;
+                                    }
+                                    .viewport-medium .g-body {
+                                        font-size: 17px;
+                                        line-height: 1.6;
+                                    }
+                                    .g-body a {
+                                        text-decoration: underline;
+                                    }
+                                    /* subhed */
+                                    .g-subhed h2 {
+                                        max-width: 460px;
+                                        margin: 2em auto 1em auto;
+                                        font: 700 1.2em/1.3em 'nyt-franklin', arial, sans-serif;
+                                        text-align: center;
+                                    }
+                                    .viewport-small-10 .g-subhed h2 {
+                                        font-size: 1.5em;
+                                    }
+                                    /* refer text box */
+                                    .g-refer {
+                                        max-width: 460px;
+                                        margin: 0 auto 25px;
+                                        padding: 12px 15px;
+                                        box-sizing: border-box;
+                                        background: #fffcd9;
+                                    }
+                                    .g-refer .g-body {
+                                        font-family: 'nyt-franklin', arial, sans-serif;
+                                        font-size: 16px;
+                                        line-height: 1.3;
+                                        margin-bottom: 0;
+                                    }
+                                    .g-refer a {
+                                        text-decoration: underline;
+                                    }
+                                    /* images */
+                                    .g-item-image {
+                                        margin: 25px auto;
+                                    }
+                                    .g-item-image img {
+                                        width: 100%;
+                                    }
+                                    /* video */
+                                    .g-item-video {
+                                        margin: 25px auto;
+                                    }
+                                    /* sources and credits */
+                                    .g-asset-source {
+                                        padding-top: 3px;
+                                    }
+                                    .g-asset-source .g-source {
+                                        font: 400 12px/15px 'nyt-franklin', arial, sans-serif;
+                                        color: #999;
+                                    }
+                                    .g-asset-source .g-pipe {
+                                        margin: 0 6px 0 3px;
+                                        font: 400 12px/12px 'nyt-franklin', arial, sans-serif;
+                                        color: #999;
+                                    }
+                                    .g-asset-source .g-caption {
+                                        font: 300 14px/17px georgia, 'times new roman', times, serif;
+                                    }
+                                    .g-asset-source .g-credit {
+                                        font: 400 12px/17px 'nyt-franklin', arial, sans-serif;
+                                        display: inline-block;
+                                        color: #999;
+                                    }
+                                    /* graphics */
+                                    .g-item-ai2html {
+                                        margin: 25px auto;
+                                    }
+                                    p.g-asset-hed {
+                                        font: 700 16px/18px 'nyt-franklin', arial, sans-serif;
+                                        margin-bottom: 0;
+                                    }
+                                    .g-map-key {
+                                        float: none;
+                                        clear: both;
+                                        overflow: hidden;
+                                        margin: 10px auto 4px auto;
+                                    }
+                                    .g-map-key .g-key-row {
+                                        margin-bottom: 5px;
+                                        margin-right: 15px;
+                                        float: left;
+                                    }
+                                    .viewport-small .g-map-key .g-key-row {
+                                        width: auto;
+                                        margin-bottom: 0;
+                                    }
+                                    .viewport-small-20 .g-map-key .g-key-row {
+                                        width: auto;
+                                    }
+                                    .g-map-key .g-key-row .g-key-rect,
+                                    .g-map-key .g-key-row .g-key-circle {
+                                        vertical-align: middle;
+                                        margin-right: 8px;
+                                        display: inline-block;
+                                    }
+                                    .g-map-key .g-key-row p {
+                                        font: 500 0.9em/1.6 'nyt-franklin', arial, sans-serif;
+                                        display: inline-block;
+                                        vertical-align: middle;
+                                        margin: -2px 0 0 0;
+                                    }
+                                    .viewport-small .g-map-key .g-key-row p {
+                                        max-width: 92%;
+                                    }
+                                    .viewport-small-20 .g-map-key .g-key-row p {
+                                        width: auto;
+                                        max-width: none;
+                                    }
+                                    .g-map-key .g-key-row .g-key-rect {
+                                        width: 22px;
+                                        height: 10px;
+                                    }
+                                    .g-map-key .g-key-row .g-key-circle {
+                                        width: 9px;
+                                        height: 9px;
+                                        border-radius: 50%;
+                                    }
+                                    .g-map-key .g-key-row .g-key-custom {
+                                        width: 20px;
+                                        height: 20px;
+                                        background-size: 100%;
+                                        display: block;
+                                        display: inline-block;
+                                        width: 24px;
+                                        height: 24px;
+                                        margin: -4px 2px 0 0;
+                                    }
+                                    .viewport-small .g-map-key .g-key-row-title p {
+                                        width: 100%;
+                                        max-width: none;
+                                    }
+                                    .g-red-dot,
+                                    .g-black-dot {
+                                        display: inline-block;
+                                        background: #d00;
+                                        color: white;
+                                        font-weight: bold;
+                                        width: 20px;
+                                        height: 20px;
+                                        font: 700 14px/1.4 'nyt-franklin', arial, sans-serif;
+                                        text-align: center;
+                                        border-radius: 10px;
+                                        line-height: 20px;
+                                    }
+                                    .g-black-dot {
+                                        background: #222;
+                                    }
+                                    /* column text */
+                                    .g-column-container {
+                                        max-width: 460px;
+                                        margin: 20px auto 0 auto;
+                                    }
+                                    .viewport-medium .g-column-container {
+                                        max-width: 1050px;
+                                    }
+                                    .viewport-large .g-column-container {
+                                        margin-bottom: 30px;
+                                    }
+                                    .g-column-container .g-column-hed {
+                                        font-family: 'nyt-franklin', arial, sans-serif;
+                                        font-weight: 700;
+                                        margin-bottom: 2px;
+                                    }
+                                    .g-column-container .g-column-col {
+                                        vertical-align: top;
+                                    }
+                                    .viewport-small .g-column-container .g-column-col {
+                                        display: block;
+                                        min-width: 100%;
+                                    }
+                                    .viewport-medium .g-column-container .g-column-col {
+                                        min-width: 0;
+                                        display: inline-block;
+                                        margin-right: 15px;
+                                    }
+                                    .viewport-medium .g-column-container .g-column-col:last-child {
+                                        margin-right: 0;
+                                    }
+                                    .g-column-container .g-column-asset,
+                                    .g-column-container .g-column-image {
+                                        margin-bottom: 8px;
+                                    }
+                                    .g-column-container .g-column-image img {
+                                        width: 100%;
+                                    }
+                                    /* tables */
+                                    .g-table {
+                                        margin: 0 auto;
+                                        margin-bottom: 25px;
+                                    }
+                                    .g-table tr {
+                                        border-bottom: 1px solid #ececec;
+                                    }
+                                    .g-table p {
+                                        font: 500 14px/1.4 'nyt-franklin', arial, sans-serif;
+                                        text-align: left;
+                                        margin: 6px 0;
+                                    }
+                                    /* charts */
+                                    .g-chart {
+                                        margin: 0 auto;
+                                        margin-bottom: 25px;
+                                        font: 500 14px/1.4 'nyt-franklin', arial, sans-serif;
+                                    }
+                                    .g-chart .g-chart-header {
+                                        font-weight: bold;
+                                    }
+                                    .g-chart .g-chart-row,
+                                    .g-chart .g-chart-header {
+                                        clear: both;
+                                        height: 22px;
+                                        margin-bottom: 9px;
+                                    }
+                                    .g-chart .g-chart-bar-container,
+                                    .g-chart .g-chart-label {
+                                        float: left;
+                                        height: 100%;
+                                    }
+                                    .g-chart .g-chart-bar-container {
+                                        margin-left: 20px;
+                                    }
+                                    .g-chart .g-chart-bar-pos,
+                                    .g-chart .g-chart-bar-neg {
+                                        height: 100%;
+                                        float: left;
+                                    }
+                                    .g-chart .g-chart-label,
+                                    .g-chart .g-chart-bar {
+                                        padding-top: 3px;
+                                    }
+                                    .g-chart .g-chart-label.not-first {
+                                        margin-left: 20px;
+                                    }
+                                    .g-chart .g-chart-bar {
+                                        height: 100%;
+                                        background: lightsteelblue;
+                                        position: relative;
+                                    }
+                                    .g-chart .g-chart-bar-label {
+                                        padding-left: 6px;
+                                    }
+                                    .g-chart .g-chart-bar-neg .g-chart-bar {
+                                        float: right;
+                                    }
+                                    .g-chart .g-chart-bar-neg .g-chart-bar-label {
+                                        text-align: right;
+                                        padding-right: 6px;
+                                        padding-left: 0px;
+                                    }
+                                    .g-chart .out-label {
+                                        padding-top: 3px;
+                                        display: none;
+                                    }
+                                    .g-chart .outside .out-label {
+                                        display: block;
+                                    }
+                                    .g-chart .outside .in-label {
+                                        display: none;
+                                    }
+                                    .g-chart .g-bold {
+                                        font-weight: bold;
+                                    }
+                                    /* grid */
+                                    .g-grid {
+                                        margin-bottom: 15px;
+                                    }
+                                    .g-grid .g-grid-item {
+                                        position: relative;
+                                        display: inline-block;
+                                        min-width: calc(50% - 5px);
+                                    }
+                                    .viewport-small-20 .g-grid .g-grid-item {
+                                        min-width: calc(33% - 5px);
+                                    }
+                                    .viewport-medium .g-grid .g-grid-item {
+                                        min-width: 0;
+                                    }
+                                    .g-grid .g-grid-item p {
+                                        font: 500 15px/1.4 'nyt-franklin', arial, sans-serif;
+                                        position: absolute;
+                                        bottom: 10px;
+                                        left: 10px;
+                                        color: #fff;
+                                        margin-bottom: 0;
+                                    }
+                                    /* lazy images */
+                                    .g-freebird-lazy {
+                                        display: block;
+                                        width: 100%;
+                                        height: auto;
+                                    }
+                                    .g-freebird-lazy.ll-init {
+                                        transition: opacity 0.3s ease-out;
+                                        opacity: 0;
+                                    }
+                                    .g-freebird-lazy.ll-loaded {
+                                        opacity: 1;
+                                    }
+                                    /* Mobile issues */
+                                    /* Get rid of border under intro and share tools on mobile */
+                                    .story-header.interactive-header {
+                                        border-bottom: none !important;
+                                    }
+                                    /* Share tools issues */
+                                    /* Pad out the kicker/sharetool space */
+                                    .story.theme-main .story-header .story-meta .kicker-container {
+                                        margin-bottom: 12px;
+                                    }
+                                    /* Override the moving sharetools on mobile */
+                                    .story.theme-main .story-header .story-meta .kicker-container .sharetools {
+                                        position: relative;
+                                        float: right;
+                                        /*right: 0px;*/
+                                        bottom: auto;
+                                        left: auto;
+                                        width: auto;
+                                        margin-top: -6px;
+                                        clear: none;
+                                    }
+                                    /* Maintain the proper space with the section name and kicker next to share tools */
+                                    .story.theme-main .story-header .story-meta .interactive-kicker {
+                                        float: left;
+                                        width: 70%;
+                                        display: inline-block;
+                                    }
+                                    .g-graphic.g-graphic-freebird .g-ad-wrapper {
+                                        margin: 30px auto;
+                                        max-width: 1050px;
+                                    }
+                                    .viewport-medium .g-graphic.g-graphic-freebird .g-ad-wrapper {
+                                        margin: 50px auto;
+                                    }
+                                    .g-graphic.g-graphic-freebird .g-ad-wrapper .ad {
+                                        border-top: 1px solid #e2e2e2 !important;
+                                        border-bottom: 1px solid #e2e2e2 !important;
+                                        margin: 0 auto;
+                                        padding: 10px 0;
+                                        overflow: hidden;
+                                        max-width: 100%;
+                                    }
+                                    .g-graphic.g-graphic-freebird .g-ad-wrapper .ad div {
+                                        margin: 0 auto;
+                                        display: block !important;
+                                    }
+                                    .g-graphic.g-graphic-freebird .g-ad-wrapper iframe {
+                                        margin: 0 auto;
+                                        display: block;
+                                    }
+                                    .g-graphic.g-graphic-freebird .g-ad-wrapper .g-ad-text {
+                                        text-align: center;
+                                        font: 500 12px/1.2 "nyt-franklin", arial, sans-serif;
+                                        color: #bfbfbf;
+                                        text-transform: uppercase;
+                                        margin-bottom: 7px;
+                                    }
+                                    .ad.top-ad {
+                                        border: none;
+                                        margin-left: auto;
+                                        margin-right: auto;
+                                    }
+                                    /* Center headlines for standalone and embedded interactives */
+                                    /* @import (inline) "nyt5/centered-headline.css"; */
+                                    /* Fullbleed interactive-graphic container */
+                                    /* remove left offset */
+                                    .viewport-medium-50 .masthead.masthead-theme-standard,
+                                    .viewport-large-20 .masthead.masthead-theme-standard {
+                                        margin-left: 0;
+                                    }
+
+                                    .viewport-large-70 .masthead.masthead-theme-standard {
+                                        margin-left: auto;
+                                    }
+
+                                    .viewport-medium-50 .masthead.masthead-theme-standard .quick-navigation,
+                                    .viewport-large-20 .masthead.masthead-theme-standard .quick-navigation {
+                                        left: 15px;
+                                    }
+
+                                    #navigation-edge {
+                                        display: none;
+                                    }
+
+                                    /* fullbleed #main */
+                                    #main {
+                                        padding-left: 0;
+                                        padding-right: 0;
+                                    }
+
+                                    .viewport-medium-10 #main {
+                                        width: 100%;
+                                        max-width: 100%;
+                                    }
+
+                                    /* constrain template containers */
+                                    .ad.top-ad {
+                                        margin-left: 0;
+                                        margin-right: 0;
+                                    }
+
+                                    .story-header.interactive-header,
+                                    .story.theme-main .story-footer,
+                                    .related-coverage {
+                                        margin-left: 10px;
+                                        margin-right: 10px;
+                                    }
+
+                                    .viewport-medium-10 .ad.top-ad,
+                                    .viewport-medium-10 .story-header.interactive-header,
+                                    .viewport-medium-10 .story.theme-main .story-footer,
+                                    .viewport-medium-10 .related-coverage {
+                                        max-width: 720px;
+                                        margin-left: auto;
+                                        margin-right: auto;
+                                    }
+
+                                    .viewport-medium-30 .ad.top-ad,
+                                    .viewport-medium-30 .story-header.interactive-header,
+                                    .viewport-medium-30 .story.theme-main .story-footer,
+                                    .viewport-medium-30 .related-coverage {
+                                        max-width: 945px;
+                                    }
+
+                                    .viewport-large-30 .ad.top-ad,
+                                    .viewport-large-30 .story-header.interactive-header,
+                                    .viewport-large-30 .story.theme-main .story-footer,
+                                    .viewport-large-30 .related-coverage {
+                                        max-width: 1050px;
+                                    }
+
+                                    .g-body, .g-map-key, .g-asset-source, .g-table-container, .g-column-container, .g-asset-hed {
+                                        padding-left: 10px;
+                                        padding-right: 10px;
+                                    }
+
+                                    .viewport-large .g-body,
+                                    .viewport-large .g-map-key,
+                                    .viewport-large .g-asset-source,
+                                    .viewport-large .g-table-container,
+                                    .viewport-large .g-column-container,
+                                    .viewport-large .g-asset-hed {
+                                        padding-left: 0;
+                                        padding-right: 0;
+                                    }
+
+                                    /* For use with LaziestLoader */
+                                    /* @import (inline) "nyt5/laziestloader.css"; */
+                                    /* Fix spacing at top of story */
+                                    .has-top-ad .story.theme-interactive,
+                                    .has-ribbon .story.theme-interactive {
+                                        margin-top: 10px;
+                                    }
+
+                                    /* Fix comments button margin */
+                                    .story.theme-interactive .comments-button.theme-kicker {
+                                        margin-top: 0;
+                                    }
+
+                                    /* Get rid of border under intro and share tools on mobile */
+                                    .page-interactive-default .story.theme-main .story-header {
+                                        border-bottom: none;
+                                    }
+
+                                    /* Pad out the kicker/sharetool space */
+                                    .story.theme-interactive .story-meta .kicker {
+                                        margin-bottom: 22px;
+                                    }
+
+                                    .viewport-medium-10 .story.theme-interactive .story-meta .kicker {
+                                        margin-bottom: 24px;
+                                    }
+
+                                    /* Override the moving sharetools on mobile */
+                                    .story.theme-interactive .story-header .story-meta .kicker-container .sharetools {
+                                        position: relative;
+                                        left: auto;
+                                        bottom: auto;
+                                        width: auto;
+                                        margin-top: -6px;
+                                        float: right;
+                                        clear: none;
+                                    }
+
+                                    /* Maintain the proper space with the section name and kicker next to share tools */
+                                    .story.theme-interactive .story-header .story-meta .interactive-kicker {
+                                        float: left;
+                                        width: 65%;
+                                        display: inline-block;
+                                    }
+
+                                    /* Gets rid of the extra space under the intro that puts too much space there in mobile and desktop */
+                                    .page-interactive-default .story.theme-main .story-header {
+                                        margin-bottom: 0;
+                                    }
+
+                                    .page-interactive-default .story.theme-main .story-header .story-meta {
+                                        margin-bottom: 10px;
+                                    }
+
+                                    /*Fixes styling on share tools at bottom of minimal interactives*/
+                                    .story.theme-minimal .sharetools.layout-horizontal{
+                                        width:auto;
+                                        margin-top:11px;
+                                    }
+                                    .story.theme-minimal .sharetools.layout-horizontal .sharetool {
+                                        display: inline-block;
+                                        border-top: 0;
+                                    }
+                                    .story.theme-minimal .sharetools.layout-horizontal .sharetool:first-child a {
+                                        margin-left: 0;
+                                        padding-left: 0;
+                                        border-left: none;
+                                    }
+                                    .story.theme-minimal .sharetools.layout-horizontal .sharetool a {
+                                        padding-left: 15px;
+                                        padding-right: 5px;
+                                        height: 20px;
+                                        border-left: 1px solid #e2e2e2;
+                                    }
+                                    .story.theme-minimal .sharetools.layout-horizontal .sharetool a:hover {
+                                        background-color: transparent;
+                                    }
+
+                                    /* uncomment to fix related content and footer layout on max_width: 720 pages */
+                                    /*
+.related-coverage {
+  max-width: 720px;
+}
+
+.viewport-medium-30 .page-footer nav ul,
+.viewport-medium-50 .page-footer nav ul {
+  margin-left: 28px;
+}
+
+.viewport-medium-30 .page-footer nav.last-nav {
+  float: none;
+}
+
+.viewport-medium-30 .page-footer nav.last-nav ul {
+  margin-left: 239px;
+}
+*/
+
+                                    .g-subhed h2 {
+                                        font: 300 24px/1.2 'nyt-franklin', Arial, sans-serif;
+                                        margin-bottom: 0.65em;
+                                    }
+                                    .viewport-small-10 .g-subhed h2 {
+                                        font-size: 28px;
+                                    }
+                                    .g-animation {
+                                        margin: 0 -15px;
+                                        max-width: calc(130%);
+                                    }
+                                    @media (min-width: 780px) {
+                                        .g-animation {
+                                            margin: 0;
+                                        }
+                                    }
+                                    .g-locator {
+                                        max-width: 300px;
+                                        margin: 100px auto 30px auto;
+                                    }
+                                    .g-locator .g-locator-in {
+                                        display: inline-block;
+                                        width: 120px;
+                                        vertical-align: middle;
+                                        z-index: -1;
+                                        position: relative;
+                                        overflow: hidden;
+                                    }
+                                    .viewport-medium .g-locator .g-locator-in {
+                                        margin: 0 -10px 0 -20px;
+                                    }
+                                    .g-locator .g-subhed {
+                                        display: inline-block;
+                                        width: calc(100% - 130px);
+                                        vertical-align: middle;
+                                        z-index: 100;
+                                        position: relative;
+                                    }
+                                    .g-request p.g-body {
+                                        padding: 8px 16px;
+                                        border-radius: 3px;
+                                        box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15);
+                                        border: 1px solid #e4e4e4;
+                                        font: 300 16px/1.4 'nyt-franklin', Arial, sans-serif;
+                                    }
+                                    div.tooltip {
+                                        top: -1000px;
+                                        position: fixed;
+                                        padding: 5px;
+                                        background: rgba(255, 255, 255, 0.95);
+                                        border: 1px solid lightgray;
+                                        pointer-events: none;
+                                        width: 300px;
+                                        font: 300 14px / 1.2 'nyt-franklin', Arial, sans-serif;
+                                    }
+                                    .tooltip-hidden {
+                                        opacity: 0;
+                                        transition: all .3s;
+                                        transition-delay: .1s;
+                                    }
+                                    @media (max-width: 590px) {
+                                        div.tooltip {
+                                            bottom: -1px;
+                                            width: calc(100%);
+                                            left: -1px !important;
+                                            right: -1px !important;
+                                            top: auto !important;
+                                            width: auto !important;
+                                        }
+                                    }
+                                    #g-harvey_basemap-box {
+                                        position: relative;
+                                    }
+                                    #g-houston-rescue-map-box {
+                                        position: absolute;
+                                        top: 0px;
+                                        font: 300 15px / 1.2 'nyt-franklin';
+                                    }
+                                    #g-houston-rescue-map-box .g-key {
+                                        width: 200px;
+                                        text-align: center;
+                                        position: absolute;
+                                        bottom: 50px;
+                                        right: 4px;
+                                        font-size: 20px;
+                                        font-weight: 600;
+                                    }
+                                    #g-houston-rescue-map-box .g-key p {
+                                        font: 300 15px / 1.2 'nyt-franklin';
+                                        display: inline-block;
+                                        margin-bottom: 0px;
+                                    }
+                                    #g-houston-rescue-map-box .g-key .g-key-circle {
+                                        width: 9px;
+                                        height: 9px;
+                                        display: inline-block;
+                                        margin-right: 8px;
+                                        position: relative;
+                                        top: -2px;
+                                        border-radius: 100%;
+                                    }
+                                    .description {
+                                        margin-left: 10px;
+                                        font-size: 15px;
+                                        line-height: 15px;
+                                        max-width: 150px;
+                                        padding: 8px 12px;
+                                        color: #000;
+                                        border-radius: 3px;
+                                        background: #ffffff;
+                                        box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.33);
+                                    }
+                                    .description:after {
+                                        content: '';
+                                        position: absolute;
+                                        left: 0;
+                                        top: 50%;
+                                        width: 0;
+                                        height: 0;
+                                        border: 5px solid transparent;
+                                        border-right-color: #ffffff;
+                                        border-left: 0;
+                                        margin-top: -5px;
+                                        margin-left: -5px;
+                                    }
+                                    .description.lefty:after {
+                                        position: absolute;
+                                        left: auto;
+                                        right: 0;
+                                        top: 50%;
+                                        width: 0;
+                                        height: 0;
+                                        border: 5px solid transparent;
+                                        border-left-color: #ffffff;
+                                        box-shadow: none;
+                                        border-right: 0;
+                                        margin-top: -5px;
+                                        margin-right: -5px;
+                                    }
+                                    .hpgraphic {
+                                        width: 573px;
+                                        position: relative;
+                                        z-index: 3;
+                                        min-height: 322px;
+                                        background: #eee;
+                                    }
+                                    .hpgraphic .g-item-ai2html {
+                                        margin: 0;
+                                    }
+                                    .hpgraphic .description {
+                                        font-size: 13px;
+                                        border-radius: 2px;
+                                        padding: 2px 5px;
+                                    }
+                                    .g-timer {
+                                        opacity: 0;
+                                    }
+                                    .g-text strong,
+                                    .g-text b {
+                                        font-family: 'nyt-franklin', arial, sans-serif;
+                                    }
+                                    </style>
+
+                                    <a href="https://www.nytimes.com/interactive/2017/08/30/us/houston-flood-rescue-cries-for-help.html">
+                                        <div class="g-graphic hpgraphic g-graphic-freebird" data-preview-slug="2017-08-30-houston-rescues">
+
+                                            <div class="g-item-ai2html" style="max-width:573px;">
+
+
+
+
+
+                                                <!-- SCOOP CSS -->
+                                                <!-- Generated by ai2html v0.65.5 - 2017-08-31 01:22 -->
+                                                <!-- ai file: harvey_hp.ai -->
+                                                <!-- preview: 2017-08-30-houston-rescues -->
+                                                <!-- scoop: houston-rescues-animation-573 -->
+                                                <style type='text/css' media='screen,print'>
+                                                    #g-harvey_hp-Artboard_2-box {
+                                                        max-width:600px;
+                                                    }
+                                                    #g-harvey_hp-Artboard_2-box .g-artboard {
+                                                        margin:0 auto;
+                                                    }
+                                                    #g-harvey_hp-Artboard_2-box .g-artboard p {
+                                                        margin:0;
+                                                    }
+                                                    .g-aiAbs {
+                                                        position:absolute;
+                                                    }
+                                                    .g-aiImg {
+                                                        display:block;
+                                                        width:100% !important;
+                                                    }
+                                                    .g-aiPointText p { white-space: nowrap; }
+                                                    #g-harvey_hp-Artboard_2 {
+                                                        position:relative;
+                                                        overflow:hidden;
+                                                        width:573px;
+                                                    }
+                                                    #g-harvey_hp-Artboard_2 p {
+                                                        font-family:nyt-franklin,arial,helvetica,sans-serif;
+                                                        font-weight:500;
+                                                        font-size:13px;
+                                                        line-height:17px;
+                                                        filter:alpha(opacity=100);
+                                                        -ms-filter:progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+                                                        opacity:1;
+                                                        letter-spacing:0.2em;
+                                                        text-align:left;
+                                                        color:rgb(156,156,156);
+                                                        text-transform:none;
+                                                        padding-bottom:0;
+                                                        padding-top:0;
+                                                        mix-blend-mode:normal;
+                                                        font-style:normal;
+                                                    }
+                                                    #g-harvey_hp-Artboard_2 .g-pstyle0 {
+                                                        font-weight:700;
+                                                        font-size:21px;
+                                                        line-height:23px;
+                                                        filter:alpha(opacity=70);
+                                                        -ms-filter:progid:DXImageTransform.Microsoft.Alpha(Opacity=70);
+                                                        opacity:0.7;
+                                                        letter-spacing:0em;
+                                                        color:rgb(0,0,0);
+                                                    }
+                                                    #g-harvey_hp-Artboard_2 .g-pstyle1 {
+                                                        text-align:center;
+                                                    }
+                                                    #g-harvey_hp-Artboard_2 .g-pstyle2 {
+                                                        font-weight:300;
+                                                        font-style:italic;
+                                                        filter:alpha(opacity=40);
+                                                        -ms-filter:progid:DXImageTransform.Microsoft.Alpha(Opacity=40);
+                                                        opacity:0.4;
+                                                        mix-blend-mode:multiply;
+                                                        letter-spacing:0.3em;
+                                                        text-align:center;
+                                                        color:rgb(5,96,147);
+                                                    }
+                                                    #g-harvey_hp-Artboard_2 .g-pstyle3 {
+                                                        font-weight:300;
+                                                        font-size:15px;
+                                                        line-height:23px;
+                                                        letter-spacing:0em;
+                                                        color:rgb(0,0,0);
+                                                    }
+                                                    #g-harvey_hp-Artboard_2 .g-pstyle4 {
+                                                        font-weight:300;
+                                                        font-size:12px;
+                                                        line-height:23px;
+                                                        filter:alpha(opacity=60);
+                                                        -ms-filter:progid:DXImageTransform.Microsoft.Alpha(Opacity=60);
+                                                        opacity:0.6;
+                                                        letter-spacing:0em;
+                                                        color:rgb(0,0,0);
+                                                    }
+
+                                                </style>
+
+                                                <!-- SCOOP HTML -->
+                                                <!-- Generated by ai2html v0.65.5 - 2017-08-31 01:22 -->
+                                                <!-- ai file: harvey_hp.ai -->
+                                                <!-- preview: 2017-08-30-houston-rescues -->
+                                                <!-- scoop: houston-rescues-animation-573 -->
+                                                <div id="g-harvey_hp-Artboard_2-box" class="ai2html">
+
+                                                    <!-- Artboard: Artboard_2 -->
+                                                    <div id="g-harvey_hp-Artboard_2" class="g-artboard g-artboard-v3">
+                                                        <img id="g-ai0-0" class="g-aiImg" src="https://static01.nyt.com/newsgraphics/2017/08/30/houston-rescues/3217ab7ea858a2c388ceacbca5f753f34faf5343/harvey_hp-Artboard_2.png"/>
+                                                        <div id="timer" class="g-timer g-aiAbs g-aiPointText" style="top:10.2033%;margin-top:-11.9px;left:5.2511%;width:150px;">
+                                                            <p class="g-pstyle0">12 a.m. Monday</p>
+                                                        </div>
+                                                        <div id="g-ai0-2" class="g-text g-aiAbs g-aiPointText" style="top:31.0397%;margin-top:-8.9px;left:75.3489%;margin-left:-7.8534%;width:92px;">
+                                                            <p class="g-pstyle1">BEAUMONT</p>
+                                                        </div>
+                                                        <div id="g-ai0-3" class="g-text g-aiAbs g-aiPointText" style="top:45.0983%;margin-top:-17.2px;left:81.9842%;margin-left:-5.6719%;width:67px;">
+                                                            <p class="g-pstyle1">PORT</p>
+                                                            <p class="g-pstyle1">ARTHUR</p>
+                                                        </div>
+                                                        <div id="g-ai0-4" class="g-text g-aiAbs g-aiPointText" style="top:60.5454%;margin-top:-8.9px;left:28.1349%;margin-left:-6.719%;width:79px;">
+                                                            <p class="g-pstyle1">HOUSTON</p>
+                                                        </div>
+                                                        <div id="g-ai0-5" class="g-text g-aiAbs g-aiPointText" style="top:72.8327%;margin-top:-17.5px;left:82.169%;margin-left:-6.8063%;width:80px;">
+                                                            <p class="g-pstyle2">GULF OF</p>
+                                                            <p class="g-pstyle2">MEXICO</p>
+                                                        </div>
+                                                        <div id="g-ai0-6" class="g-text g-aiAbs g-aiPointText" style="top:93.7756%;margin-top:-11.9px;left:79.5415%;width:102px;">
+                                                            <p class="g-pstyle3">Rescue request</p>
+                                                        </div>
+                                                        <div id="g-ai0-7" class="g-text g-aiAbs g-aiPointText" style="top:93.4021%;margin-top:-11.7px;left:1.6973%;width:45px;">
+                                                            <p class="g-pstyle4">10 miles</p>
+                                                        </div>
+                                                    </div>
+
+                                                </div>
+
+
+
+
+
+                                            </div>
+
+                                        </div>
+                                    </a>
+
+                                    <script>
+                                        define('_nytg/2017-08-30-houston-rescues/assets', function() { return 'https://static01.nyt.com/newsgraphics/2017/08/30/houston-rescues/3217ab7ea858a2c388ceacbca5f753f34faf5343/'; });
+                                        define('_nytg/2017-08-30-houston-rescues/big-assets', function() { return 'https://static01.nyt.com/newsgraphics/2017/08/30/houston-rescues/assets/'; });
+
+                                        require(['foundation/main'], function() {
+                                            require(['https://static01.nyt.com/newsgraphics/2017/08/30/houston-rescues/3217ab7ea858a2c388ceacbca5f753f34faf5343/build.js']); // generated from src/script.js
+                                        });
+                                    </script>
+                                    <!-- Pipeline: 2017-08-30-houston-rescues August 31, 2017, 01:24AM 3217ab7ea858a2c388ceacbca5f753f34faf5343 --></div>
+                                <div class="collection">
+                                    <div class="photo-spot-region"><div class="story theme-summary lede"><article class="story theme-summary" id="topnews-100000005401681" data-story-id="100000005401681" data-rank="1" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                        <h2 class="story-heading"><a href="https://www.nytimes.com/interactive/2017/08/30/us/houston-flood-rescue-cries-for-help.html">‘Running Out of Time’</a></h2>
+
+
+                                        <p class="summary">As Houston was overcome by floodwaters, thousands of people cried out for help online.</p>
+
+
+                                    </article>
+                                    </div></div></div>
+                                <div class="collection">
+                                    <div style="margin-top: +5px;"></div></div>
+                                <div class="collection">
+                                    <hr class="single-rule" />
+                                </div>
+                                <div class="collection">
+                                    <style>
+                                        .nythpSplitCode .column { margin-left: 21px; }
+                                        .nythpSplitCode .column:first-child { margin-left: 0px; }
+                                        .nythpSplitCode.layout { background: none; }
+                                        .nythpSplitCode .media.photo.medium-thumb { float: none; margin-left: 0; }
+                                    </style>
+
+                                    <div class="layout nythpSplitCode wide-b-layout">
+                                        <div class="column"><div></div>
+                                            <div class="collection">
+                                                <article class="story theme-summary" id="topnews-100000005400393" data-story-id="100000005400393" data-rank="0" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/us/victims-harvey-death-toll-houston.html">Clinging to Her Drowning Mother, a Girl Survives</a></h2>
+
+                                                    <p class="byline">By SIMON ROMERO and JULIE BOSMAN </p>
+
+                                                    <p class="summary">“Mama was saying her prayers,” 3-year-old Jordyn Grace told a relative.</p>
+
+
+                                                </article>
+                                            </div>
+                                            <div class="collection headlines">
+                                                <ul class="theme-news-headlines">
+                                                    <li>
+                                                        <div style="margin-top: -10px;"></div>            </li>
+                                                    <li>
+                                                        <article class="story" id="topnews-100000005400407" data-story-id="100000005400407" data-rank="1" data-collection-renderstyle="HpBlogHeadline">
+                                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/us/harvey-death-toll.html">Stories Emerge of Harvey’s Victims as Death Toll Rises</a></h2>
+                                                        </article>
+                                                    </li>
+                                                    <li>
+                                                        <article class="story" id="topnews-100000005398786" data-story-id="100000005398786" data-rank="2" data-collection-renderstyle="HpBlogHeadline">
+                                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/us/hurricane-center-timeline.html">From Forecast to Disaster: A Timeline</a></h2>
+                                                        </article>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="collection">
+                                            </div></div>
+                                        <div class="column b-column"><div></div>
+                                            <div class="collection">
+                                                <article class="story theme-summary" id="topnews-100000005401072" data-story-id="100000005401072" data-rank="0" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/us/houston-flooding-growth-regulation.html">Houston, the Limitless City, Is Forced to Consider Its Limits</a></h2>
+
+                                                    <p class="byline">By MANNY FERNANDEZ and RICHARD FAUSSET </p>
+
+                                                    <p class="summary">A muscular metropolitan area that embraced growth now wonders whether growth made its flooding woes worse.</p>
+
+
+                                                </article>
+                                            </div>
+                                            <div class="collection headlines">
+                                                <ul class="theme-news-headlines">
+                                                    <li>
+                                                        <div style="margin-top: -10px;"></div>            </li>
+                                                    <li>
+                                                        <article class="story" id="topnews-100000005396839" data-story-id="100000005396839" data-rank="1" data-collection-renderstyle="HpBlogHeadline">
+                                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/business/harvey-recovery-houston-businesses.html">After Harvey, Will Big Business Repay Houston’s Generosity?</a></h2>
+                                                        </article>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="collection">
+                                                <article class="story theme-summary" id="topnews-100000005400885" data-story-id="100000005400885" data-rank="0" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/business/harvey-aid-sba-disaster-loans.html">Victims Face Hurdles, and Maybe Bills, in Getting Aid</a></h2>
+
+                                                    <p class="byline">By STACY COWLEY </p>
+
+                                                    <p class="summary">Thousands are applying for federal assistance, but it may be slow to arrive and require them to take on debt.</p>
+
+
+                                                </article>
+                                            </div>
+                                            <div class="collection headlines">
+                                                <ul class="theme-news-headlines">
+                                                    <li>
+                                                        <div style="margin-top: -10px;"></div>            </li>
+                                                    <li>
+                                                        <article class="story" id="topnews-100000005396158" data-story-id="100000005396158" data-rank="1" data-collection-renderstyle="HpBlogHeadline">
+                                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/28/us/donate-harvey-charities-scams.html">Where to Donate to Storm Victims (and How to Avoid Scams)</a></h2>
+                                                        </article>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="collection">
+                                            </div></div>
+                                        <div class="column"><div></div>
+                                            <div class="collection">
+                                            </div></div></div></div>
+                                <div class="collection">
+                                </div></div></div>
+                        <div class="column megaSPanC"><div></div>
+                            <div class="collection">
+                                <style type="text/css">
+                                    .paywall-hp-note {
+                                        padding: 13px 15px 12px 15px;
+                                        background-color: #f7f7f7;
+                                        border-radius: 2px;
+                                        margin-bottom: 18px;
+                                    }
+                                    .paywall-hp-note:after {
+                                        content: "";
+                                        display: table;
+                                        clear: both;
+                                    }
+                                    .paywall-hp-note h5,
+                                    .paywall-hp-note p {
+                                        font: 400 14px/16px 'nyt-cheltenham-sh',georgia,'times new roman',serif;
+                                        color: #808080;
+                                        -webkit-font-smoothing: antialiased;
+                                    }
+                                    .paywall-hp-note h5 {
+                                        font-weight: 700;
+                                        color: #4d4d4d;
+                                        margin-bottom: 9px;
+                                    }
+                                    .paywall-hp-note p {
+                                        font-style: italic;
+                                        margin-bottom: 0;
+                                    }
+                                </style>
+                                <div class="paywall-hp-note">
+                                    <h5>To Our Readers</h5>
+                                    <p>The Times is providing free digital access to coverage of the storm.</p>
+                                </div></div>
+                            <div class="collection">
+                                <hr class="single-rule" style="width: 50%; text-align: center; margin: 12px auto 0;" />
+
+                            </div>
+                            <div class="collection">
+                                <article class="story theme-summary" id="topnews-100000005399973" data-story-id="100000005399973" data-rank="0" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/us/port-arthur-flooding.html">Port Arthur Overcome by Instant Flooding: ‘Our Whole City Is Underwater’</a></h2>
+
+                                    <p class="byline">By JONAH ENGEL BROMWICH </p>
+
+                                    <p class="summary">Jefferson County, Tex., about 100 miles east of Houston, was “slammed with 20 inches of rainfall” overnight. Thousands of people were stranded on their roofs, on top of cars and in attics.</p>
+
+
+                                </article>
+                            </div>
+                            <div class="collection">
+                                <figure class="story theme-feature video media video-promo-small updated-video-promo-small">
+                                    <a href="https://www.nytimes.com/video/us/100000005400001/harvey-houston-port-arthur-flooding.html">
+                                        <div class="video-promo-small-container" style="background-image: url('https://static01.nyt.com/images/2017/08/31/us/31storm4_xp/31storm4_xp-filmstrip.jpg');">
+                                            <div class="metadata">
+                                                <div class="play-button-and-duration">
+                                                    <div class="play-icon">
+                                                        <svg class="play-circle" height="28" width="28">
+                                                            <circle cx="14" cy="14" r="13" stroke="#FFF" fill="transparent" stroke-width="1.5" />
+                                                        </svg>
+                                                        <svg version="1.2" class="play-triangle" height="10" width="10">
+                                                            <polyline points="5,1.2264973081037427 10,9.88675134594813 0,9.88675134594813" transform="rotate(90, 5, 5)"></polyline>
+                                                        </svg>
+                                                    </div>
+                                                    <div class="duration">
+                                                        <span>1:36</span>
+                                                    </div>
+                                                </div>
+                                                <h2 class="story-heading">
+                                                    Path of Destruction Continues                            </h2>
+                                                <div class="orientation-icon">
+                                                    <svg width="28px" height="28px" viewBox="0 0 28 28" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink">
+                                                        <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                                                            <g id="Compass-Cover-ACol">
+                                                                <g id="360-View-Indicator">
+                                                                    <circle id="Oval-44" fill-opacity="0.1" fill="#000000" cx="14" cy="14" r="12.75"></circle>
+                                                                    <path d="M14,28 C21.7319865,28 28,21.7319865 28,14 C28,6.2680135 21.7319865,0 14,0 C6.2680135,0 0,6.2680135 0,14 C0,21.7319865 6.2680135,28 14,28 Z M14,26.75 C21.0416306,26.75 26.75,21.0416306 26.75,14 C26.75,6.95836944 21.0416306,1.25 14,1.25 C6.95836944,1.25 1.25,6.95836944 1.25,14 C1.25,21.0416306 6.95836944,26.75 14,26.75 Z" id="Border" fill="#FFFFFF"></path>
+                                                                    <g id="eyes" transform="translate(9.488845, 14.454531)" fill="#FFFFFF">
+                                                                        <ellipse id="Oval-12" cx="2.01115463" cy="2.04546933" rx="1.5" ry="1.5"></ellipse>
+                                                                        <ellipse id="Oval-12-Copy" cx="7.01115463" cy="2.04546933" rx="1.5" ry="1.5"></ellipse>
+                                                                    </g>
+                                                                    <path d="M13.9960842,13 L21.5,5.88357462 C19.5796583,4.05113973 16.9264365,3 13.9960843,3 C11.065732,3 8.42034167,4.05113973 6.5,5.88357462 L13.9960842,13 Z" id="view" fill="#FFFFFF"></path>
+                                                                </g>
+                                                            </g>
+                                                        </g>
+                                                    </svg>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </a>
+                                    <figcaption class="caption">
+                                        <p class="credit">By MALACHY BROWNE, BARBARA MARCOLINI and CHRIS CIRILLO</p>
+                                    </figcaption>
+                                </figure>
+                            </div>
+                            <div class="collection headlines">
+                                <ul class="theme-news-headlines">
+                                    <li>
+                                        <article class="story" id="topnews-100000005398038" data-story-id="100000005398038" data-rank="0" data-collection-renderstyle="HpBlogHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/29/us/harvey-email-callout.html">Are You Affected? We Want to Hear From You</a></h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="collection">
+                            </div></div>
+
+                        <div style="background-color: #fff;"><div></div>
+                        </div>
+                    </div>
+                </div></div>
+            <div class="collection">
+                <script>function getFlexData() { return {"data":{"item":[{"thumb":"https:\/\/static01.nyt.com\/images\/2017\/09\/01\/science\/01WATER1\/01WATER1-videoSixteenByNine310.jpg","type":"article","headline":"A Sea of Hazards in Floodwaters","link":"https:\/\/www.nytimes.com\/2017\/08\/31\/us\/houston-contaminated-floodwaters.html"},{"thumb":"https:\/\/static01.nyt.com\/images\/2017\/08\/31\/insider\/mattress-mack\/mattress-mack-videoSixteenByNine310.jpg","type":"video","headline":"A Mattress Store Turned Shelter","link":"https:\/\/www.nytimes.com\/video\/us\/100000005398367\/houston-harvey-mattress-shelter.html"},{"thumb":"https:\/\/static01.nyt.com\/images\/2017\/08\/31\/us\/stormpics74\/stormpics74-videoSixteenByNine310.jpg","type":"slideshow","headline":"Harvey in Pictures","link":"https:\/\/www.nytimes.com\/2017\/08\/27\/us\/harvey-pictures-hurricane-storm.html?mcubz=0&_r=0"},{"thumb":"https:\/\/static01.nyt.com\/images\/2017\/08\/31\/dining\/360-tamircover\/360-tamircover-videoSixteenByNine310.jpg","type":"video","headline":"The Daily 360: Submerged Streets ","link":"https:\/\/www.nytimes.com\/video\/us\/100000005399523\/harvey-houston-flooding-rescue.html"}]}}; }var NYTD=NYTD || {}; NYTD.FlexTypes = NYTD.FlexTypes || []; NYTD.FlexTypes.push({"target":"FT100000005396835","type":"HP Thumbstrip","data":{"item":[{"thumb":"https:\/\/static01.nyt.com\/images\/2017\/09\/01\/science\/01WATER1\/01WATER1-videoSixteenByNine310.jpg","type":"article","headline":"A Sea of Hazards in Floodwaters","link":"https:\/\/www.nytimes.com\/2017\/08\/31\/us\/houston-contaminated-floodwaters.html"},{"thumb":"https:\/\/static01.nyt.com\/images\/2017\/08\/31\/insider\/mattress-mack\/mattress-mack-videoSixteenByNine310.jpg","type":"video","headline":"A Mattress Store Turned Shelter","link":"https:\/\/www.nytimes.com\/video\/us\/100000005398367\/houston-harvey-mattress-shelter.html"},{"thumb":"https:\/\/static01.nyt.com\/images\/2017\/08\/31\/us\/stormpics74\/stormpics74-videoSixteenByNine310.jpg","type":"slideshow","headline":"Harvey in Pictures","link":"https:\/\/www.nytimes.com\/2017\/08\/27\/us\/harvey-pictures-hurricane-storm.html?mcubz=0&_r=0"},{"thumb":"https:\/\/static01.nyt.com\/images\/2017\/08\/31\/dining\/360-tamircover\/360-tamircover-videoSixteenByNine310.jpg","type":"video","headline":"The Daily 360: Submerged Streets ","link":"https:\/\/www.nytimes.com\/video\/us\/100000005399523\/harvey-houston-flooding-rescue.html"}]}});</script><link rel="stylesheet" type="text/css" href="https://static01.nyt.com/newsgraphics/2015/hp-thumbstrip/assets/build.css" />
+                <style>
+                    .nytd-hp-thumbstrip{ display:flex; }
+                    .nytd-hp-thumbstrip .ts-link{ width:100%;  }
+                    .nytd-hp-thumbstrip .ts-link .ts-item{ width:94%;  }
+                </style>
+
+                <script>
+                    var NYTG_ASSETS = "_assets/";
+                    var NYTG_BIG_ASSETS = "_big_assets/";
+                    require(['foundation/main'], function() {
+                        require(["https://static01.nyt.com/newsgraphics/2015/hp-thumbstrip/assets/build.js"]);
+                    });
+                </script><div id="FT100000005396835"></div></div>
+            <div class="collection">
+                <hr class="scotch-rule" /></div>
+    </div><!-- close span-abc-region -->
+
+    <div class="span-ab-layout layout">
+
+        <div class="ab-column column">
+
+            <section id="top-news" class="top-news">
+                <h2 class="section-heading visually-hidden">Top News</h2>
+
+
+
+
+                <div class="wide-b-layout layout">
+
+                    <div class="a-column column">
+
+                        <div class="first-column-region region">
+
+                            <div class="collection">
+                                <article class="story theme-summary" id="topnews-100000005399055" data-story-id="100000005399055" data-rank="0" data-collection-renderstyle="HpSumSmallMedia">
+
+
+                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/us/politics/trump-missouri-tax-plan.html">Trump Pitches Tax Cuts on Business as Aiding Middle Class</a></h2>
+
+                                    <p class="byline">By JULIE HIRSCHFELD DAVIS and BINYAMIN APPELBAUM </p>
+
+                                    <div class="thumb">
+                                        <a href="https://www.nytimes.com/2017/08/30/us/politics/trump-missouri-tax-plan.html"><img src="https://static01.nyt.com/images/2017/08/31/us/31dc-trump-promo/31dc-trump-promo-thumbStandard.jpg" alt=""></a>
+                                    </div>
+
+                                    <p class="summary">
+                                        In a speech on Wednesday in Springfield, Mo., President Trump laid out the case for cutting taxes for businesses and individuals and for simplifying the tax code.    </p>
+
+                                    <p class="theme-comments">
+                                        <a href="https://www.nytimes.com/2017/08/30/us/politics/trump-missouri-tax-plan.html?hp&amp;target=comments#commentsContainer" class="comments-link"><i class="icon sprite-icon comments-icon"></i><span class="comment-count">&nbsp;Comments</span></a>
+                                    </p>
+
+                                </article>
+
+                            </div>
+                            <div class="collection">
+                                <article class="story theme-summary" id="topnews-100000005398833" data-story-id="100000005398833" data-rank="0" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/29/business/economy/trump-corporate-tax-plan.html">Trump Tax Plan May Free Corporate Dollars. Then What?</a></h2>
+
+                                    <p class="byline">By PATRICIA COHEN </p>
+
+                                    <p class="summary">Republicans are promising to stimulate investment and create jobs. But steps to undo tax dodges may not produce the intended economic lift.</p>
+
+                                    <p class="theme-comments">
+                                        <a href="https://www.nytimes.com/2017/08/29/business/economy/trump-corporate-tax-plan.html?hp&amp;target=comments#commentsContainer" class="comments-link"><i class="icon sprite-icon comments-icon"></i><span class="comment-count">&nbsp;Comments</span></a>
+                                    </p>
+
+                                </article>
+                            </div>
+                            <hr class="single-rule" /><div class="collection">
+                            <article class="story theme-summary" id="topnews-100000005401510" data-story-id="100000005401510" data-rank="0" data-collection-renderstyle="HpSumMediumMedia" data-start-time="" data-end-time="">
+
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/us/judge-texas-sanctuary-cities.html">Federal Judge Blocks Texas’ Ban on ‘Sanctuary Cities’</a></h2>
+
+                                <p class="byline">By MANNY FERNANDEZ </p>
+
+                                <p class="summary">
+                                    The temporary ruling prevents the state from going ahead with provisions that were to go into effect on Friday.        </p>
+
+
+
+                                <figure class="media photo medium-thumb">
+                                    <div class="image">
+                                        <a href="https://www.nytimes.com/2017/08/30/us/judge-texas-sanctuary-cities.html"><img src="https://static01.nyt.com/images/2017/08/31/us/31sanctuary/31sanctuary-mediumFlexible177.jpg" alt="" /></a>
+                                    </div>
+                                </figure>
+                            </article>
+                        </div>
+                            <hr class="single-rule" /><div class="collection">
+                            <article class="story theme-summary" id="topnews-100000005401018" data-story-id="100000005401018" data-rank="0" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/us/politics/trump-obamacare-enrollment-markets-subsidies.html">Seeking to Stabilize Health Markets, but Offering Few Details</a></h2>
+
+                                <p class="byline">By ROBERT PEAR </p>
+
+                                <p class="summary">A Trump administration official refused to say what, if anything, the government would do to encourage people to sign up for health insurance under the Affordable Care Act.</p>
+
+
+                            </article>
+                        </div>
+                            <hr class="single-rule" /><div class="collection">
+                            <article class="story theme-summary" id="topnews-100000005399964" data-story-id="100000005399964" data-rank="0" data-collection-renderstyle="HpSumMediumMedia" data-start-time="" data-end-time="">
+
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/us/politics/trump-north-korea-extortion-money.html">On North Korea, Trump Says ‘Talking Is Not the Answer!’</a></h2>
+
+                                <p class="byline">By MARK LANDLER </p>
+
+                                <p class="summary">
+                                    While Mr. Trump’s threats against North Korea have been unnerving, it is the prospect of a risky dialogue that most unsettles former officials.        </p>
+
+
+
+                                <figure class="media photo medium-thumb">
+                                    <div class="image">
+                                        <a href="https://www.nytimes.com/2017/08/30/us/politics/trump-north-korea-extortion-money.html"><img src="https://static01.nyt.com/images/2017/08/31/us/31dc-prexy1/merlin-to-scoop-126571670-887690-mediumFlexible177.jpg" alt="" /></a>
+                                    </div>
+                                </figure>
+                            </article>
+                        </div>
+                            <div class="collection headlines">
+                                <h3 class="kicker collection-kicker">More in Politics</h3>
+                                <ul class="theme-news-headlines">
+                                    <li>
+                                        <article class="story" id="topnews-100000005400483" data-story-id="100000005400483" data-rank="0" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/us/politics/trump-russia-michael-cohen.html">Trump Lawyer ‘Vehemently’ Denies Russian Collusion</a> </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" id="topnews-100000005401238" data-story-id="100000005401238" data-rank="1" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/us/politics/us-aid-pakistan-terror.html">U.S. Gives Military Assistance to Pakistan, With Strings Attached</a> </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </div>
+                            <hr class="single-rule" /><div class="collection">
+                            <article class="story theme-summary" id="topnews-100000005400786" data-story-id="100000005400786" data-rank="0" data-collection-renderstyle="HpSum" data-start-time="" data-end-time="">
+
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/health/gene-therapy-cancer.html">F.D.A. Approves Gene-Altering Leukemia Treatment</a></h2>
+
+                                <p class="byline">By DENISE GRADY </p>
+
+                                <p class="summary">The Food and Drug Administration approved the first treatment that alters a patient’s cells to fight cancer. It will cost $475,000.</p>
+
+
+                            </article>
+                        </div>
+                            <hr class="single-rule" /><div class="collection headlines">
+                            <h3 class="kicker collection-kicker">More News</h3>
+                            <ul class="theme-news-headlines">
+                                <li>
+                                    <article class="story" id="topnews-100000005401772" data-story-id="100000005401772" data-rank="0" data-collection-renderstyle="HpBlogHeadline">
+                                        <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/31/world/asia/building-collapse-in-mumbai-kills-at-least-7.html">Building Collapse in Mumbai Kills at Least 7</a></h2>
+                                    </article>
+                                </li>
+                                <li>
+                                    <article class="story" id="topnews-100000005401309" data-story-id="100000005401309" data-rank="1" data-collection-renderstyle="HpBlogHeadline">
+                                        <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/sports/tennis/maria-sharapova-timea-babos-us-open.html">U.S. Open: Maria Sharapova, With No Tears, Advances</a></h2>
+                                    </article>
+                                </li>
+                                <li>
+                                    <article class="story" id="topnews-100000005399026" data-story-id="100000005399026" data-rank="2" data-collection-renderstyle="HpBlogHeadline">
+                                        <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/us/politics/eric-schmidt-google-new-america.html">Think Tank Backed by Google Ousts Critic of Monopolies</a></h2>
+                                    </article>
+                                </li>
+                                <li>
+                                    <article class="story" id="topnews-100000005401178" data-story-id="100000005401178" data-rank="3" data-collection-renderstyle="HpBlogHeadline">
+                                        <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/world/americas/brazil-amazon-mining-temer-environmentalists-judge.html">Brazilian Judge Stymies Plan for Mining in Amazon Region</a></h2>
+                                    </article>
+                                </li>
+                                <li>
+                                    <article class="story" id="topnews-100000005400012" data-story-id="100000005400012" data-rank="4" data-collection-renderstyle="HpBlogHeadline">
+                                        <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/world/europe/trump-press-united-nations.html">U.N. Human Rights Chief Condemns Trump’s Attacks on Media</a></h2>
+                                    </article>
+                                </li>
+                                <li>
+                                    <article class="story" id="topnews-100000005400793" data-story-id="100000005400793" data-rank="5" data-collection-renderstyle="HpBlogHeadline">
+                                        <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/world/asia/afghanistan-troop-totals.html">11,000 U.S. Troops in Afghanistan, Pentagon Says</a></h2>
+                                    </article>
+                                </li>
+                            </ul>
+                        </div>
+                            <hr class="single-rule" /><div class="collection">
+                            <!--
+
+======================================================
+
+THIS IS A GENERATED TEMPLATE FILE. DO NOT EDIT.
+
+======================================================
+
+-->
+                            <!-- this is generated from src/style.css -->
+                            <style>.tips-promo {
+                                position: relative;
+                                width: 100%;
+                                height: auto; }
+                            .tips-promo .nyt-logo {
+                                position: absolute;
+                                top: 1rem;
+                                left: 0;
+                                right: 0;
+                                margin: 0 auto;
+                                width: 6rem; }
+                            .tips-promo svg {
+                                width: 6rem;
+                                margin: 0 auto; }
+                            .tips-promo .text-bubble {
+                                padding: 1rem 0; }
+                            .tips-promo .text-bubble h1 {
+                                font-family: "nyt-cheltenham", times, serif;
+                                color: black;
+                                position: relative;
+                                font-size: 1.5rem;
+                                font-weight: 400;
+                                line-height: 0.9;
+                                -webkit-font-smoothing: antialiased;
+                                z-index: 0; }
+                            .tips-promo .text-bubble h2 {
+                                font-family: "nyt-cheltenham-sh", times, serif;
+                                color: black;
+                                position: relative;
+                                font-size: 14px;
+                                font-weight: 400;
+                                line-height: 1.3;
+                                -webkit-font-smoothing: antialiased;
+                                z-index: 0;
+                                padding-top: 0.5rem; }
+                            .tips-promo .text-bubble .contact {
+                                font-family: "nyt-cheltenham-sh", times, serif;
+                                display: inline-block;
+                                border-style: none;
+                                border-color: transparent;
+                                font-size: 13px;
+                                font-weight: bold;
+                                padding: 0;
+                                background: none;
+                                color: #326891;
+                                text-decoration: underline; }
+                            </style>
+
+                            <div id="g-graphic" data-preview-slug="2016-10-31-tips-hp">
+                                <div class="tips-promo">
+                                    <div class="text-bubble">
+                                        <h1><a href="https://www.nytimes.com/tips">Got a confidential news tip?</a></h1>
+                                        <h2>The New York Times offers several ways to get in touch with and provide materials to our journalists.     <a href="https://www.nytimes.com/tips"><span class="contact">Learn more</span></a>.</h2>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <script>
+                                var _gaq = _gaq || [];
+                                define('_nytg/2016-10-31-tips-hp/assets', function() { return 'https://static01.nyt.com/newsgraphics/2016/10/31/tips-hp/00b5b741a6c5682e24f945c547f78fbe98f2c27f/'; });
+                                define('_nytg/2016-10-31-tips-hp/big-assets', function() { return 'https://static01.nyt.com/newsgraphics/2016/10/31/tips-hp/assets/'; });
+
+                                require(['foundation/main'], function() {
+                                    require(['https://static01.nyt.com/newsgraphics/2016/10/31/tips-hp/00b5b741a6c5682e24f945c547f78fbe98f2c27f/build.js']); // generated from src/script.js
+                                });
+                            </script>
+                            <!-- Pipeline: 2016-10-31-tips-hp December 22, 2016, 09:17PM 00b5b741a6c5682e24f945c547f78fbe98f2c27f --></div>
+
+                        </div><!-- close first-column-region -->
+
+                    </div><!-- close a-column -->
+
+                    <div class="b-column column">
+
+
+
+                        <div class="second-column-region region">
+
+                            <div class="collection">
+                                <script>function getFlexData() { return {"data":{"options":{"width":375,"height":380,"jsonp":"https:\/\/static01.nyt.com\/slideshow\/2017\/08\/28\/world\/europe\/tk.slideshow.jsonp","link":"https:\/\/www.nytimes.com\/2017\/08\/30\/world\/europe\/princess-diana-death-anniversary.html"},"photos":{"photo":{"url":"","credit":""}},"advanced":{"delay":3,"limitjsonp":0,"rendition":"largeHorizontal375","targetoverride":"","abbreviatecredits":false}}}; }var NYTD=NYTD || {}; NYTD.FlexTypes = NYTD.FlexTypes || []; NYTD.FlexTypes.push({"target":"FT100000005396180","type":"FadingSlideShow","data":{"options":{"width":375,"height":380,"jsonp":"https:\/\/static01.nyt.com\/slideshow\/2017\/08\/28\/world\/europe\/tk.slideshow.jsonp","link":"https:\/\/www.nytimes.com\/2017\/08\/30\/world\/europe\/princess-diana-death-anniversary.html"},"photos":{"photo":{"url":"","credit":""}},"advanced":{"delay":3,"limitjsonp":0,"rendition":"largeHorizontal375","targetoverride":"","abbreviatecredits":false}}});</script><script src="https://static01.nyt.com/packages/js/multimedia/libs/jquery-1.7.1.min.js"></script><script src="https://static01.nyt.com/packages/js/multimedia/bundles/projects/2013/FadingSlideShow2.js"></script>
+                                <style type="text/css">
+                                    .edition-domestic .span-ab-layout .nytmm_FadingSlideShow .credit, .edition-international .span-ab-layout .nytmm_FadingSlideShow .credit {
+                                        color: #BAB8B3;
+                                        display: inline-block;
+                                        font-family: arial,helvetica,sans-serif;
+                                        font-size: 0.5625rem !important;
+                                        font-weight: 400;
+                                        line-height: 0.75rem;
+                                    }
+                                </style><div id="FT100000005396180"></div></div>
+                            <div class="collection">
+                                <div style="margin-top: +25px;"></div></div>
+                            <div class="collection">
+                                <article class="story theme-feature" id="topnews-100000005401664" data-story-id="100000005401664" data-rank="0" data-collection-renderstyle="LargeMediaHeadlineSumCentered">
+
+
+
+                                    <h1 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/world/europe/princess-diana-death-anniversary.html">Death of Diana Transformed </br> the Monarchy, and Britain Itself</a></h1>
+
+                                    <p class="summary">Twenty years after her death, the influence of Diana, Princess of Wales, can still be felt in unexpected ways in Britain.</p>
+
+                                    <p class="byline">By SARAH LYALL </p>
+
+
+                                    <ul class="refer theme-news-headlines">
+                                        <li>
+                                            <article class="story" id="topnews-100000005401664">
+                                                <h2 class="refer-heading"><a href="https://www.nytimes.com/2017/08/30/world/europe/princess-diana-anniversary.html">Diana’s Public Life, in Photos and Headlines</a> </h2>
+                                            </article>
+                                        </li>
+                                        <li>
+                                            <article class="story" id="topnews-100000005401664">
+                                                <h2 class="refer-heading"><a href="https://www.nytimes.com/2017/08/30/world/europe/uk-princess-diana-20th-anniversary.html">Death of a Princess: Times Journalists Recall Covering Diana</a> </h2>
+                                            </article>
+                                        </li>
+                                    </ul>
+                                </article>
+                            </div>
+                            <hr class="single-rule" /><div class="collection">
+                            <article class="story theme-summary timedBriefing timedBriefingHide" id="topnews-100000005368865" data-story-id="100000005368865" data-rank="0" data-collection-renderstyle="HpSumMediumMediaHigh" data-start-time="05:00" data-end-time="13:00">
+
+                                <figure class="media photo medium-thumb">
+                                    <div class="image">
+                                        <a href="https://www.nytimes.com/2017/08/31/briefing/harvey-diana-david-tang.html"><img src="https://static01.nyt.com/images/2017/09/01/world/31USBriefing-Texas/31USBriefing-Texas-mediumFlexible177-v2.gif" alt="" /></a>
+                                    </div>
+                                </figure>
+
+
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/31/briefing/harvey-diana-david-tang.html">Your Thursday Briefing</a></h2>
+
+                                <p class="byline">By CHRIS STANFORD <time class="timestamp" datetime="2017-08-31" data-eastern-timestamp="6:34 AM" data-utc-timestamp="1504175651">6:34 AM ET</time></p>
+
+                                <p class="summary">
+                                    Here’s what you need to know to start your day.        </p>
+
+
+                                <ul class="refer theme-news-headlines">
+                                    <li>
+                                        <article class="story" id="topnews-100000005368865">
+                                            <h2 class="refer-heading"><a href="https://www.nytimes.com/2017/08/31/nyregion/new-york-today-hurricanes-in-nyc-harvey-tropical-storm.html">New York Today: Reflecting on Harvey, in the Northeast</a> <time class="timestamp" data-eastern-timestamp="6:00 AM" datetime="2017-08-31" data-utc-timestamp="1504173618000">6:00 AM</time></h2>
+                                        </article>
+                                    </li>
+                                </ul>
+
+                            </article>
+                        </div>
+                            <div class="collection">
+                                <style>
+                                    /*default display conditions*/
+                                    .nythpCAToday {display: none;}
+                                    /*geocoded display conditions*/
+                                    html.geo-region-CA .nythpCAToday  {display: block;}
+
+                                    .nythpCAToday article::before {
+                                        content: "";
+                                        background: #e2e2e2;
+                                        width: 187px;
+                                        height: 1px;
+                                        margin: 12px 0 12px 93px;
+                                    }
+
+                                    .second-column-region .collection:first-child .nythpCAToday article::before {
+                                        display: none;
+                                    }
+
+                                    .second-column-region .collection:first-child .nythpCAToday { border-bottom: 1px solid #ccc;
+                                        padding-bottom: 8px;
+                                    }
+
+                                </style>
+
+                                <div class="nythpCAToday">
+
+
+                                </div></div>
+                            <hr class="single-rule" /><div class="collection">
+                            <link rel="stylesheet" type="text/css" href="https://web-player.art19.com/releases/0.0.42.css">
+                            <link rel="stylesheet" type="text/css" href="https://static01.nyt.com/packages/html/mobile/2017/Audio/nyt-micro-player.min.css">
+                            <script src="https://static01.nyt.com/packages/html/mobile/2017/Audio/nyt-micro-player-template.min.js"></script>
+                            <style>
+                                .audio-brief .image {
+                                    width: 75px;
+                                    height: 75px;
+                                    float: right;
+                                    clear: right;
+                                    margin: 4px 0 6px 12px;
+                                }
+                                .audio-brief .summary {
+                                    padding-bottom: 10px;
+                                }
+                                .audio-brief .audio {
+                                    margin: 0;
+                                }
+                                .audio-brief .art19-web-player {
+                                    margin-bottom: 0;
+                                }
+                                .audio-brief .art19-web-player.awp-micro .awp-left {
+                                    border-right: none;
+                                }
+                                .audio-brief .art19-web-player.awp-micro .awp-brand-logo {
+                                    padding: 0;
+                                }
+                                .audio-brief .awp-brand-logo img {
+                                    display: none;
+                                }
+
+                                .audio-brief .awp-embed-button{
+                                    cursor: pointer;
+                                }
+                                #daily-sub-links{
+                                    width:100%;
+                                    padding:0;
+                                    margin:-10px 0 0 0;
+                                }
+                                #daily-sub-links p{
+                                    font-family:"nyt-franklin",arial,helvetica,sans-serif;
+                                    font-weight:400;
+                                    font-size: 12px;
+                                    line-height: 15px;
+                                    color:#000;
+                                }
+                                #daily-sub-links p a{
+                                    display:inline-block;
+                                    color: #326891;
+                                    padding-right: 8px;
+                                    padding-left: 6px;
+                                    border-right:1px solid #ccc;
+                                }
+                                #daily-sub-links p a:last-child{
+                                    border-right:none;
+                                }
+                            </style>
+                            <article class="story audio-brief theme-summary">
+                                <div class="image">
+                                    <a href="https://www.nytimes.com/column/the-daily">
+                                        <img src="https://static01.nyt.com/images/2017/02/23/podcasts/the-daily/the-daily-logo-png-version/the-daily-logo-png-version-thumbLarge-v3.png" height="75" width="75" alt="The Daily Logo">
+                                    </a>
+                                </div>
+                                <h3 class="kicker"><a href="https://www.nytimes.com/podcasts/">Audio</a></h3>
+                                <h2 class="story-heading">
+                                    <a href="https://www.nytimes.com/thedaily">
+                                        Listen to ‘The Daily’
+                                    </a>
+                                </h2>
+                                <p class="summary">The uniquely American success story of a city built on a swampy bayou, and how Harvey’s destruction recasts the narrative.</p>
+                                <figure id="audio" class="art19 media audio" aria-label="media" role="group" data-audio-url="" data-audio-duration="">
+                                    <span class="visually-hidden">Audio</span>
+                                    <div data-require-template="art19-web-player/templates/nyt-micro-player" data-preload='false' class="art19-web-player awp-micro awp-theme-light" data-episode-id='1ed84d54-17bf-4d6b-be2f-405f51402cc6' data-squery='max-width:280px=awp-nyt-size-1 max-width:460px=awp-nyt-size-2' data-download-enabled='false' data-embed-enabled='false' data-brand-logo-enabled='false' data-ad-progress-color='#4d7b9f' data-emit-events='true' >
+                                    </div>
+                                </figure>
+                            </article>
+                            <div id="daily-sub-links">
+                                <p>Follow The Daily:   <a href="https://itunes.apple.com/us/podcast/the-daily/id1200361736?mt=2&ign-mpt=uo%3D4" target="_blank">Apple Podcasts</a> <a href="https://play.radiopublic.com/88f7d8c3-7289-4dc6-b300-5ba71b43f5e5" target="_blank">Radio Public</a> <a href="http://www.stitcher.com/podcast/the-new-york-times/the-daily-10" target="_blank">Stitcher</a></p>
+                            </div>
+                            <script src="https://web-player.art19.com/releases/0.0.42.js"></script></div>
+                            <hr class="single-rule" /><div class="collection">
+                            <div class="hpHeader">
+                                <h6><a href="http://www.nytimes.com/spotlight/times-tips?contentCollection=smarter-living">Smarter Living</a></h6>
+                            </div><div class="nythpSmarterLiving smarterLiving-promo-region region">
+                            <article class="story theme-summary" id="topnews-100000005400342" data-story-id="100000005400342" data-rank="2" data-collection-renderstyle="HpSumSmallMediaHigh">
+
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/31/smarter-living/5-cheap-ish-wellness-items-you-didnt-know-you-needed.html">5 Wellness Items You Didn’t Know You Needed</a></h2>
+
+                                <div class="thumb">
+                                    <a href="https://www.nytimes.com/2017/08/31/smarter-living/5-cheap-ish-wellness-items-you-didnt-know-you-needed.html"><img src="https://static01.nyt.com/images/2017/08/31/us/31sl-newsletter/31sl-newsletter-thumbStandard.jpg" alt=""></a>
+                                </div>
+
+                                <p class="byline">By TIM HERRERA <time class="timestamp" datetime="2017-08-31" data-eastern-timestamp="2:45 AM" data-utc-timestamp="1504161901">2:45 AM ET</time></p>
+
+                                <p class="summary">
+                                    Welcome to the latest edition of the Smarter Living newsletter.    </p>
+
+
+                            </article>
+                            <article class="story theme-summary" id="topnews-100000005278952" data-story-id="100000005278952" data-rank="3" data-collection-renderstyle="HpSumSmallMediaHigh">
+
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/2017/07/19/travel/british-airways-flight-safety-videos.html">5 Flight Safety Videos Worth Watching</a></h2>
+
+                                <div class="thumb">
+                                    <a href="https://www.nytimes.com/2017/07/19/travel/british-airways-flight-safety-videos.html"><img src="https://static01.nyt.com/images/2017/07/18/travel/18flight-videos1/18flight-videos1-thumbStandard.png" alt=""></a>
+                                </div>
+
+                                <p class="byline">By JUSTIN SABLICH </p>
+
+                                <p class="summary">
+                                    A new British Airways video featuring some of the country’s best-known actors and comedians is the latest in a long line of entertaining flight safety films.    </p>
+
+
+                            </article>
+                        </div>
+
+
+                            <!-- Begin A/B Personalization Test -->
+
+                            <style>
+                                .flag-smarterLivingRec-on .nythpSmarterLiving {
+                                    display: none;
+                                }
+                            </style>
+                            <script type="text/javascript">
+                                require(['foundation/main'], function (main) {
+                                    require([
+                                            'underscore/nyt',
+                                            'jquery/nyt',
+                                            'foundation/views/base-view'
+                                        ],
+                                        function (_, $, BaseView) {
+                                            var SmarterLiving = BaseView.extend({
+
+                                                template: _.template('<article class="story theme-summary" id="topnews-<%= id %>"' +
+                                                    ' data-story-id="<%= id %>" data-collection-renderstyle="HpSumSmallMediaHigh"><h2 class="story-heading">' +
+                                                    '<a href="<%= url %>"><%= headline %></a></h2><div class="thumb"><a href="<%= url %>">' +
+                                                    '<img src="<%= thumb_url %>" alt=""></a></div></article>'),
+
+                                                events: {
+                                                    'click article a': 'handleArticleLinkClick'
+                                                },
+
+                                                articles: [],
+
+                                                initialize: function () {
+                                                    const view = this;
+
+                                                    if (!this.pageManager.flag('smarterLivingRec')) {
+                                                        return;
+                                                    }
+
+                                                    this.$el = $('.nythpSmarterLiving');
+                                                    this.setupImpressionTracking = _.once(this._setupImpressionTracking);
+                                                    $.ajax(
+                                                        {
+                                                            url: 'https://rec.api.nytimes.com/svc/recommendations/v4/smarter_living.json',
+                                                            xhrFields: {
+                                                                withCredentials: true
+                                                            }
+                                                        })
+                                                        .done(function(data) {
+                                                            view.setupImpressionTracking();
+                                                            _.each(data.assets, function(item) {
+                                                                view.articles.push(item.url);
+                                                            });
+                                                            // iterate over the existing articles
+                                                            view.$el.find('article').each(function (index) {
+                                                                // replace with articles from rec service
+                                                                $(this).replaceWith(view.template(data.assets[index]));
+                                                            });
+                                                        })
+                                                        .always(function() {
+                                                            // unhide articles
+                                                            view.$el.css('display', 'block');
+                                                        });
+                                                },
+
+                                                _setupImpressionTracking: function () {
+                                                    if (this.pageManager.isComponentVisible(this.$el)) {
+                                                        this.recordTrackingImpression();
+                                                    } else {
+                                                        this.subscribe('nyt:page-scroll', this.handleScroll);
+                                                    }
+                                                },
+
+                                                handleArticleLinkClick: function (ev) {
+                                                    const view = this;
+                                                    const $el = $(ev.currentTarget);
+                                                    var href = this.trackingAppendParams($el.attr('href'), {
+                                                        'action': 'click',
+                                                        'pgtype': 'Homepage',
+                                                        'clickSource': 'story-heading',
+                                                        'module': 'smarter-living',
+                                                        'region': 'second-column-region',
+                                                        'contentCollection': 'smarter-living',
+                                                        'mData': $.param({
+                                                            articles: view.articles
+                                                        }),
+                                                    });
+
+                                                    $el.attr('href', href);
+                                                },
+
+                                                handleScroll: function () {
+                                                    if (this.pageManager.isComponentVisible(this.$el)) {
+                                                        this.recordTrackingImpression();
+                                                        this.stopSubscribing('nyt:page-scroll');
+                                                    }
+                                                },
+
+                                                recordTrackingImpression: function () {
+                                                    const view = this;
+                                                    this.trackingTriggerImpression('Impression', {
+                                                        'module': 'smarter-living',
+                                                        'pgtype': 'Homepage',
+                                                        'region': 'second-column-region',
+                                                        'action': 'impression',
+                                                        'proxyEventType': 'impression',
+                                                        'timestamp': new Date().getTime(),
+                                                        'mData': {
+                                                            articles: view.articles
+                                                        },
+                                                    });
+                                                },
+
+                                            });
+
+                                            new SmarterLiving();
+                                        });
+                                });
+                            </script>
+                            <div id="g-graphic" class="nythp-smarter-living-formonly-email-promo notification-widget story">
+                                <hr class="single-rule" style="width: 50%; text-align: center; margin: 12px auto 12px;" />
+
+                                <p class="theme-summary">Get a weekly roundup of the best advice from The Times on living a better, smarter, more fulfilling life.</p>
+                                <div id="smarter-living-form-only"></div>
+
+                            </div>
+
+                            <script>
+                                require.config({
+                                    paths: {
+                                        'nytint/email-subscriber' : 'https://int.nyt.com/applications/email-subscriber/client'
+                                    }
+                                });
+
+                                require(['foundation/main'], function() {
+                                    require(['nytint/email-subscriber'], function(Subscriber) {
+                                        Subscriber.setup({
+                                            containerId: 'smarter-living-form-only',
+                                            productCode: 'SL',
+                                            elementToHideOnSubscribe: '.nythp-smarter-living-formonly-email-promo',
+                                            text: {unregisteredButton: 'Sign Up',
+                                                unregisteredPlaceholder: 'Get Smarter Living by email',
+                                                registeredButton: 'Sign Up',
+                                                alreadySubscribedMessage: 'You’re already subscribed.',
+                                                thanksMessage: 'You’ve signed up as %email%',
+                                                emailPreferencesLinkText: 'Update your mail preferences »',
+                                                errorMessage: 'Error submitting, please try again.',
+                                                registeredWelcome: 'Get Smarter Living by email'}
+                                        });
+
+                                        setTimeout(function(){
+                                            var widget = document.getElementById('smarter-living-form-only');
+                                            var container = widget.getElementsByTagName('div')[0];
+                                            var form = widget.getElementsByTagName('form')[0];
+                                            var status = container.getAttribute('data-status');
+                                            var notify = widget.getElementsByClassName('notify-email')[0];
+
+                                            if(notify !== undefined){
+
+                                                var origtext = notify.getAttribute('placeholder');
+                                                var newtext = 'Please enter your email address';
+                                                var button = container.getElementsByTagName('button')[0];
+
+                                                widget.setAttribute('class','clearfix');
+
+                                                notify.addEventListener('mouseover',function(){
+                                                    notify.setAttribute('placeholder',newtext);
+                                                });
+
+                                                notify.addEventListener('mouseout',function(){
+                                                    notify.setAttribute('placeholder',origtext);
+                                                });
+
+                                                notify.addEventListener('focus',function(){
+                                                    notify.setAttribute('placeholder','');
+                                                });
+
+                                            }
+
+                                            if(form !== undefined){
+                                                notify.addEventListener('keyup',function(){
+                                                    form.setAttribute('class','dirtyform');
+                                                });
+                                                container.setAttribute('class','not-signedin');
+                                            } else {
+                                                container.setAttribute('class','signedin');
+                                            }
+                                        },2000);
+
+                                    });
+                                });
+                            </script></div>
+                            <div class="collection">
+                                <style>
+                                    .signup-favor {
+                                        text-align: center;
+                                        color: #326891;
+                                        cursor: pointer;
+                                        padding-top: 15px;
+                                        padding-bottom: 15px;
+                                    }
+
+                                    .signup-favor.top-border {
+                                        margin-top: 8px;
+                                        padding-top: 32px;
+                                        border-top: 1px solid #ccc;
+                                    }
+
+                                    .signup-favor.bottom-border {
+                                        padding-bottom: 33px;
+                                        border-bottom: 1px solid #ccc;
+                                    }
+
+                                    .signup-favor a:hover {
+                                        text-decoration: none;
+                                    }
+
+                                    .signup-favor .tagline {
+                                        display: block;
+                                        font-size: 1.25rem;
+                                        line-height: 1.75rem;
+                                        font-weight: 700;
+                                        font-style: normal;
+                                        font-family: "nyt-cheltenham", georgia, "times new roman", times, serif;
+                                        color: #000;
+                                    }
+
+                                    .signup-favor .subscribe {
+                                        font-size: 12px;
+                                        line-height: 1.0625rem;
+                                        font-weight: 500;
+                                        font-style: normal;
+                                        font-family: "nyt-franklin", arial, helvetica, sans-serif;
+                                        color: #326891;
+                                        border-bottom: 1px solid rgba(50,104,145,.2);
+                                        letter-spacing: .04em;
+                                        margin: 5px auto 0;
+                                        padding-bottom: 1px;
+                                        text-transform: uppercase;
+                                        display: inline-block;
+                                        -moz-transition: border 0.2s ease;
+                                        -webkit-transition: border 0.2s ease;
+                                        -ms-transition: border 0.2s ease;
+                                        transition: border 0.2s ease;
+                                    }
+                                    .signup-favor .tagline .support {
+                                        font-size: 1.25rem;
+                                    }
+
+                                    .signup-favor .tagline .no-break {
+                                        white-space: nowrap;
+                                    }
+                                    .signup-favor:hover .subscribe {
+                                        border-color: rgba(50,104,145,1);
+                                    }
+
+                                    #nythp-sub-promo { display: none; }
+
+                                </style>
+                                <div id="g-graphic" class="sub-promo-click">
+                                    <div class="signup-favor hidden" id="signup-favor">
+                                        <a href="https://www.nytimes.com/DesktopHome" class="subscribe-link">
+                                            <span class="tagline"><span class="no-break">Journalism that matters.</span> <br /><span class="no-break">More essential than ever.</span></span>
+                                            <span class="subscribe">Subscribe to the Times</span>
+                                        </a>
+
+                                    </div>
+                                </div>
+
+                                <div id="nythp-sub-promo"></div>
+
+                                <script type="text/javascript">
+                                    require(['foundation/main'], function(main) {
+                                        require(['jquery/nyt', 'underscore/nyt', 'foundation/models/user-data', 'foundation/tracking/tracking-mixin', 'foundation/views/page-manager', 'foundation/hosts'],
+                                            function ($, _, userData, trackingMixin, pageManager, hosts) {
+                                                var signupPromo = {
+
+                                                    taglines: {
+                                                        'promo1': '<span style="white-space: nowrap">Journalism that matters.</span><br /><span style="white-space: nowrap"> More essential than ever.</span>',
+                                                        'promo2': '<span style="white-space: nowrap">Independent journalism.</span><br /><span style="white-space: nowrap">More essential than ever.</span>',
+                                                        'promo3': 'Real reporting. Real news.',
+                                                        'promo4': 'Independent. Trusted. Real.',
+                                                        'promo5': 'Real journalism. <span style="white-space: nowrap">Like nowhere else.</span>',
+                                                        'promo6': 'Truth is hard to find.<br /><span style="white-space: nowrap; font-size: 1.25rem;">But easier with 1,000+ journalists looking.</span>'
+                                                    },
+
+                                                    /**
+                                                     * Initialization called when instantiating the view
+                                                     *
+                                                     * @method initialize
+                                                     **/
+                                                    initialize: function () {
+                                                        this.$el = $('#signup-favor');
+                                                        $(document).on('click', "#g-graphic.sub-promo-click", function(e){
+                                                            if (e) {
+                                                                e.preventDefault();
+                                                            }
+                                                            signupPromo.handleClick();
+                                                        });
+
+                                                        this.version = 'promo1';
+
+                                                        userData.ready(function() {
+                                                            signupPromo.handleUserReady();
+                                                        });
+
+                                                        this.link = 'https://www.nytimes.com/DesktopHome';
+
+                                                    },
+
+
+                                                    trackImpression: function() {
+
+                                                        setTimeout(function() {
+                                                            signupPromo.tracking.trackingTriggerRaw(
+                                                                signupPromo.version,
+                                                                {
+                                                                    module: 'election-sub-desktop-home',
+                                                                    action: 'impression'
+                                                                },
+                                                                'impression'
+                                                            );
+                                                        }, 1000);
+
+                                                    },
+
+
+
+                                                    handleUserReady: function () {
+
+                                                        var view = this;
+                                                        console.log("abra "+ window.NYTD.Abra('www-signup-favor-test-v4'));
+
+                                                        if (window.NYTD.Abra('www-signup-favor-test-v4') == 'control') {
+                                                            return;
+                                                        }
+
+
+                                                        if (userData) {
+
+                                                            if (!userData.isHomeDeliverySubscriber() &&
+                                                                !userData.isWebSubscriber() &&
+                                                                !userData.isMobileSubscriber() &&
+                                                                !userData.isTabletSubscriber()) {
+                                                                if (!$('html').hasClass('geo-country-US')) {
+                                                                    this.link = 'https://www.nytimes.com/DesktopHomeINYT';
+                                                                    this.$el.find(".subscribe-link").attr("href", "http://www.nytimes.com/DesktopHomeINYT")
+                                                                }
+                                                                this.switchText();
+                                                            } else {
+                                                                this.$el.find('.tagline').html('<span class="no-break support">Support the mission of The Times.</span>');
+                                                                this.$el.find('.subscribe').html('Sponsor a student subscription today.');
+                                                                this.version = 'studentSponsor';
+                                                                this.link = 'https://www.nytimes.com/NativeSponsor';
+                                                                this.$el.find('.subscribe-link').attr('href', 'https://www.nytimes.com/NativeSponsor');
+                                                            }
+
+                                                            // if user is not already subscribed, show the element
+                                                            this.$el.removeClass('hidden');
+                                                            this.trackImpression();
+                                                            if (this.$el.closest('.column').hasClass('ab-column')){
+                                                                this.$el.addClass('top-border');
+                                                            } else if (this.$el.closest('.column').hasClass('b-column')) {
+                                                                this.$el.addClass('top-border').addClass('bottom-border');
+                                                            }
+
+                                                        }
+
+                                                    },
+
+                                                    switchText: function () {
+                                                        var hasAbra = false;
+
+                                                        hasAbra = window.NYTD && window.NYTD.Abra && window.NYTD.Abra('www-signup-favor-test-v4');
+                                                        // check if this is part of an AB test
+                                                        if (hasAbra) {
+                                                            switch (window.NYTD.Abra('www-signup-favor-test-v4')) {
+                                                                case '1':
+                                                                    this.$el.find('.tagline').html(this.taglines['promo1']);
+                                                                    this.version = 'promo1';
+                                                                    break;
+                                                                case '2':
+                                                                    this.$el.find('.tagline').html(this.taglines['promo2']);
+                                                                    this.version = 'promo2';
+                                                                    break;
+                                                                case '3':
+                                                                    this.$el.find('.tagline').html(this.taglines['promo3']);
+                                                                    this.version = 'promo3';
+                                                                    break;
+                                                                case '4':
+                                                                    this.$el.find('.tagline').html(this.taglines['promo4']);
+                                                                    this.version = 'promo4';
+                                                                    break;
+                                                                case '5':
+                                                                    this.$el.find('.tagline').html(this.taglines['promo5']);
+                                                                    this.version = 'promo5';
+                                                                    break;
+                                                                case '6':
+                                                                    this.$el.find('.tagline').html(this.taglines['promo6']);
+                                                                    this.version = 'promo6';
+                                                                    break;
+                                                            }
+                                                        }
+                                                    },
+
+                                                    handleClick: function (e) {
+
+                                                        if (e) {
+                                                            e.preventDefault();
+                                                        }
+
+                                                        this.tracking.trackingTriggerRaw(
+                                                            this.version,
+                                                            {
+                                                                module: 'election-sub-desktop-home',
+                                                                action: 'click',
+                                                                eventName: 'sign-up'
+                                                            },
+                                                            'interaction'
+                                                        );
+
+                                                        setTimeout(function() {
+                                                            window.location.href = signupPromo.link;
+                                                        }, 300);
+
+                                                    },
+                                                };
+
+                                                signupPromo.tracking = trackingMixin;
+                                                signupPromo.pageManager = pageManager;
+                                                signupPromo.hosts = hosts;
+                                                signupPromo.initialize();
+                                            });
+                                    });
+
+                                </script></div>
+                            <div class="collection">
+                                <article class="story theme-summary" id="topnews-100000005400160" data-story-id="100000005400160" data-rank="0" data-collection-renderstyle="HpSumSmallMediaHigh">
+
+                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/nyregion/ordering-review-of-statues-puts-de-blasio-in-tricky-spot.html">Ordering Review of Statues Puts de Blasio in Tricky Spot</a></h2>
+
+                                    <div class="thumb">
+                                        <a href="https://www.nytimes.com/2017/08/30/nyregion/ordering-review-of-statues-puts-de-blasio-in-tricky-spot.html"><img src="https://static01.nyt.com/images/2017/08/31/nyregion/31monument1/31monument1-thumbStandard.jpg" alt=""></a>
+                                    </div>
+
+                                    <p class="byline">By WILLIAM NEUMAN </p>
+
+                                    <p class="summary">
+                                        Since Mayor de Blasio called for a review of all possible symbols of hate, he has been peppered with questions about how far it will go.    </p>
+
+
+                                </article>
+                            </div>
+                            <hr class="single-rule" /><div class="collection">
+                            <article class="story theme-summary" id="topnews-100000005399785" data-story-id="100000005399785" data-rank="0" data-collection-renderstyle="HpSumSmallMediaHigh">
+
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/business/david-tang-dead-fashion-retailer.html">David Tang, Fashion Retailer and Raconteur, Dies at 63</a></h2>
+
+                                <div class="thumb">
+                                    <a href="https://www.nytimes.com/2017/08/30/business/david-tang-dead-fashion-retailer.html"><img src="https://static01.nyt.com/images/2017/08/31/business/31TANG1/31TANG1-thumbStandard-v2.jpg" alt=""></a>
+                                </div>
+
+                                <p class="byline">By KEITH BRADSHER and ELIZABETH PATON </p>
+
+                                <p class="summary">
+                                    A lifelong entrepreneur from a wealthy family, he founded a succession of businesses catering to the affluent but also backed democracy for Hong Kong.    </p>
+
+
+                            </article>
+                        </div>
+                            <hr class="single-rule" /><div class="collection">
+                            <article class="story theme-video theme-video-updated"
+                                     id="topnews-100000005343497"
+                                     data-story-id="100000005343497"
+                                     data-rank="0"
+                                     data-collection-renderstyle="VideoEmbed">
+                                <figure class="promo media video embedded"
+                                        data-position="secondcolumn"
+                                        data-page="homepage"
+                                        data-videoid="100000005343497"
+                                        data-headline="Forty Years of Voyager"
+                                        data-summary="Long after they have stopped communicating with Earth, the twin Voyager spacecraft will forever drift among the stars."
+                                        data-live="false"
+                                        data-media-action="inline"
+                                        data-autoplay="false"
+                                        data-collection-renderstyle="VideoEmbed">
+                                    <figcaption class="caption">
+                                        <p class="credit credit-right" itemprop="copyrightHolder">
+                                            Video by DENNIS OVERBYE, JONATHAN CORUM and JASON DRAKEFORD        </p>
+                                    </figcaption>
+                                </figure>
+                                <p class="summary">Long after they have stopped communicating with Earth, the twin Voyager spacecraft will forever drift among the stars.</p>
+                            </article>
+                        </div>
+                            <hr class="single-rule" /><div class="collection">
+                            <article class="story theme-summary" id="topnews-100000005387970" data-story-id="100000005387970" data-rank="0" data-collection-renderstyle="HpSumSmallMediaHigh">
+
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/31/arts/television/young-sheldon-the-big-bang-theory-spinoff-cbs.html">‘Young Sheldon’ Remakes ‘The Big Bang Theory’ Formula</a></h2>
+
+                                <div class="thumb">
+                                    <a href="https://www.nytimes.com/2017/08/31/arts/television/young-sheldon-the-big-bang-theory-spinoff-cbs.html"><img src="https://static01.nyt.com/images/2017/09/10/arts/10YOUNGSHELDON1/10YOUNGSHELDON1-thumbStandard.jpg" alt=""></a>
+                                </div>
+
+                                <p class="byline">By JOHN KOBLIN <time class="timestamp" datetime="2017-08-31" data-eastern-timestamp="5:00 AM" data-utc-timestamp="1504170026">5:00 AM ET</time></p>
+
+                                <p class="summary">
+                                    For the CBS prequel, co-creator Chuck Lorre abandoned the format that made him successful by instead using a single camera, voice-over narration and a child actor.    </p>
+
+
+                            </article>
+                        </div>
+                            <div class="collection">
+                                <style>
+                                    /*default display conditions*/
+                                    .nythpNYRegionPromo {display: none;}
+                                    /*geocoded display conditions*/
+                                    html.geo-dma-501 .nythpNYRegionPromo, html.geo-region-NJ .nythpNYRegionPromo {display: block;}
+
+                                    .nythpNYRegionPromo {
+                                        border-top: 1px solid #e2e2e2;
+                                        margin-top: 10px;
+                                        padding-top: 10px;
+                                    }
+                                </style>
+
+
+                                <div class="nythpNYRegionPromo nygeo-promo-region region"><div>
+
+                                    <article class="story theme-summary" id="topnews-100000005398183" data-story-id="100000005398183" data-rank="1" data-collection-renderstyle="HpSumSmallMediaHigh">
+
+                                        <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/nyregion/acs-legal-aid-lawyers-facebook-posts.html">Lawyers Under Scrutiny for Family Court Facebook Posts</a></h2>
+
+                                        <div class="thumb">
+                                            <a href="https://www.nytimes.com/2017/08/30/nyregion/acs-legal-aid-lawyers-facebook-posts.html"><img src="https://static01.nyt.com/images/2017/08/31/nyregion/31acs/31acs-thumbStandard.jpg" alt=""></a>
+                                        </div>
+
+                                        <p class="byline">By NIKITA STEWART </p>
+
+                                        <p class="summary">
+                                            Lawyers who worked for the Legal Aid Society and the city’s child welfare agency are under review for social media posts that mocked people in Family Court in Queens.    </p>
+
+
+                                    </article>
+                                </div></div></div>
+                            <hr class="single-rule" /><div class="collection">
+                            <style>
+                                .nythpGeoMBPromo-AU, .nythpGeoMBPromo-EU, .nythpGeoMBPromo-AS, .nythpGeoCalTodayPromo  {
+                                    display: none;
+                                }
+
+                                html.geo-continent-AS .nythpGeoMBPromo-AS, html.geo-continent-OC .nythpGeoMBPromo-AU, html.geo-country-AU .nythpGeoMBPromo-AU, html.geo-continent-EU .nythpGeoMBPromo-EU, html.geo-continent-AF .nythpGeoMBPromo-EU, html.geo-continent-NA.geo-region-CA .nythpGeoCalTodayPromo { display: block; }
+                                html.geo-continent-AS .nythpGeoMBPromo, html.geo-continent-OC .nythpGeoMBPromo, html.geo-country-AU .nythpGeoMBPromo, html.geo-continent-EU .nythpGeoMBPromo, html.geo-continent-AF .nythpGeoMBPromo, html.geo-continent-NA.geo-region-CA .nythpGeoMBPromo { display: none; }
+
+                            </style>
+
+
+
+
+                            <article class="story theme-summary nythpGeoMBPromo-AU" id="topnews-100000005085460" data-story-id="100000005085460" data-rank="0" data-collection-renderstyle="HpSumMediumMediaHigh" data-start-time="" data-end-time="">
+                                <figure class="media photo medium-thumb">
+                                    <div class="image">
+                                        <a href="https://www.nytimes.com/newsletters/morning-briefing-australia"><img src="https://static01.nyt.com/images/2017/05/08/world/asia/australia-briefing-signup01/australia-briefing-signup01-mediumFlexible177.png" alt=""></a>
+                                    </div>
+                                </figure>
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/newsletters/morning-briefing-australia">Morning Briefing: Australia Edition</a></h2>
+                                <p class="summary">The news and stories that matter to readers in Australia. Sign up to get it by email, Monday through Friday.    </p>
+
+                                <div id="g-graphic" class="nythp-morning-briefing-email-promo notification-widget">
+                                    <div id="morning-briefing-widget-au"></div>
+                                </div>
+
+                                <script>
+                                    require.config({
+                                        paths: {
+                                            'nytint/email-subscriber' : 'https://int.nyt.com/applications/email-subscriber/client'
+                                        }
+                                    });
+
+                                    require(['foundation/main'], function() {
+                                        require(['nytint/email-subscriber'], function(Subscriber) {
+                                            Subscriber.setup({
+                                                containerId: 'morning-briefing-widget-au',
+                                                productCode: 'MBAU',
+                                                /* elementToHideOnSubscribe: '.nythp-morning-briefing-email-promo', */
+                                                text: {unregisteredButton: 'Sign Up',
+                                                    unregisteredPlaceholder: 'Get the Morning Briefing by email.',
+                                                    registeredButton: 'Sign Up',
+                                                    alreadySubscribedMessage: 'You’re already subscribed.',
+                                                    thanksMessage: 'You’ve signed up as %email%',
+                                                    emailPreferencesLinkText: 'Update your mail preferences »',
+                                                    errorMessage: 'Error submitting, please try again.',
+                                                    registeredWelcome: 'Get the Morning Briefing by email.'}
+                                            });
+
+                                            setTimeout(function(){
+                                                var widget = document.getElementById('morning-briefing-widget-au');
+                                                var container = widget.getElementsByTagName('div')[0];
+                                                var form = widget.getElementsByTagName('form')[0];
+                                                var status = container.getAttribute('data-status');
+                                                var notify = widget.getElementsByClassName('notify-email')[0];
+
+                                                if(notify !== undefined){
+
+                                                    var origtext = notify.getAttribute('placeholder');
+                                                    var newtext = 'Please enter your email address';
+                                                    var button = container.getElementsByTagName('button')[0];
+
+                                                    widget.setAttribute('class','clearfix');
+
+                                                    notify.addEventListener('mouseover',function(){
+                                                        notify.setAttribute('placeholder',newtext);
+                                                    });
+
+                                                    notify.addEventListener('mouseout',function(){
+                                                        notify.setAttribute('placeholder',origtext);
+                                                    });
+
+                                                    notify.addEventListener('focus',function(){
+                                                        notify.setAttribute('placeholder','');
+                                                    });
+
+                                                }
+
+                                                if(form !== undefined){
+                                                    notify.addEventListener('keyup',function(){
+                                                        form.setAttribute('class','dirtyform');
+                                                    });
+                                                    container.setAttribute('class','not-signedin');
+                                                } else {
+                                                    container.setAttribute('class','signedin');
+                                                }
+                                            },2000);
+
+                                        });
+                                    });
+                                </script>
+
+                            </article>
+
+
+
+
+                            <article class="story theme-summary nythpGeoMBPromo-AS" id="topnews-100000005085459" data-story-id="100000005085459" data-rank="1" data-collection-renderstyle="HpSumMediumMediaHigh" data-start-time="" data-end-time="">
+                                <figure class="media photo medium-thumb">
+                                    <div class="image">
+                                        <a href="https://www.nytimes.com/newsletters/morning-briefing-asia"><img src="https://static01.nyt.com/images/2017/05/26/world/26asiapromo2/26asiapromo2-mediumFlexible177.jpg" alt=""></a>
+                                    </div>
+                                </figure>
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/newsletters/morning-briefing-asia">Morning Briefing: Asia Edition</a></h2>
+                                <p class="summary">The news and stories that matter to readers in Asia. Sign up to get it by email, Monday through Friday.    </p>
+
+                                <div id="g-graphic" class="nythp-morning-briefing-email-promo notification-widget">
+                                    <div id="morning-briefing-widget-as"></div>
+                                </div>
+
+                                <script>
+                                    require.config({
+                                        paths: {
+                                            'nytint/email-subscriber' : 'https://int.nyt.com/applications/email-subscriber/client'
+                                        }
+                                    });
+
+                                    require(['foundation/main'], function() {
+                                        require(['nytint/email-subscriber'], function(Subscriber) {
+                                            Subscriber.setup({
+                                                containerId: 'morning-briefing-widget-as',
+                                                productCode: 'MBAE',
+                                                /* elementToHideOnSubscribe: '.nythp-morning-briefing-email-promo', */
+                                                text: {unregisteredButton: 'Sign Up',
+                                                    unregisteredPlaceholder: 'Get the Morning Briefing by email.',
+                                                    registeredButton: 'Sign Up',
+                                                    alreadySubscribedMessage: 'You’re already subscribed.',
+                                                    thanksMessage: 'You’ve signed up as %email%',
+                                                    emailPreferencesLinkText: 'Update your mail preferences »',
+                                                    errorMessage: 'Error submitting, please try again.',
+                                                    registeredWelcome: 'Get the Morning Briefing by email.'}
+                                            });
+
+                                            setTimeout(function(){
+                                                var widget = document.getElementById('morning-briefing-widget-as');
+                                                var container = widget.getElementsByTagName('div')[0];
+                                                var form = widget.getElementsByTagName('form')[0];
+                                                var status = container.getAttribute('data-status');
+                                                var notify = widget.getElementsByClassName('notify-email')[0];
+
+                                                if(notify !== undefined){
+
+                                                    var origtext = notify.getAttribute('placeholder');
+                                                    var newtext = 'Please enter your email address';
+                                                    var button = container.getElementsByTagName('button')[0];
+
+                                                    widget.setAttribute('class','clearfix');
+
+                                                    notify.addEventListener('mouseover',function(){
+                                                        notify.setAttribute('placeholder',newtext);
+                                                    });
+
+                                                    notify.addEventListener('mouseout',function(){
+                                                        notify.setAttribute('placeholder',origtext);
+                                                    });
+
+                                                    notify.addEventListener('focus',function(){
+                                                        notify.setAttribute('placeholder','');
+                                                    });
+
+                                                }
+
+                                                if(form !== undefined){
+                                                    notify.addEventListener('keyup',function(){
+                                                        form.setAttribute('class','dirtyform');
+                                                    });
+                                                    container.setAttribute('class','not-signedin');
+                                                } else {
+                                                    container.setAttribute('class','signedin');
+                                                }
+                                            },2000);
+
+                                        });
+                                    });
+                                </script>
+
+
+                            </article>
+
+
+
+
+
+                            <article class="story theme-summary nythpGeoMBPromo-EU" id="topnews-100000004906098" data-story-id="100000004906098" data-rank="2" data-collection-renderstyle="HpSumMediumMediaHigh" data-start-time="" data-end-time="">
+                                <figure class="media photo medium-thumb">
+                                    <div class="image">
+                                        <a href="https://www.nytimes.com/newsletters/morning-briefing-europe"><img src="https://static01.nyt.com/images/2017/05/26/world/26europeanpromo2/26europeanpromo2-mediumFlexible177.jpg" alt=""></a>
+                                    </div>
+                                </figure>
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/newsletters/morning-briefing-europe">Morning Briefing: Europe Edition</a></h2>
+                                <p class="summary">The news and stories that matter to readers in Europe. Sign up to get it by email, Monday through Friday.    </p>
+                                <div id="g-graphic" class="nythp-morning-briefing-email-promo notification-widget">
+                                    <div id="morning-briefing-widget-eu"></div>
+                                </div>
+
+                                <script>
+                                    require.config({
+                                        paths: {
+                                            'nytint/email-subscriber' : 'https://int.nyt.com/applications/email-subscriber/client'
+                                        }
+                                    });
+
+                                    require(['foundation/main'], function() {
+                                        require(['nytint/email-subscriber'], function(Subscriber) {
+                                            Subscriber.setup({
+                                                containerId: 'morning-briefing-widget-eu',
+                                                productCode: 'MBE',
+                                                /* elementToHideOnSubscribe: '.nythp-morning-briefing-email-promo', */
+                                                text: {unregisteredButton: 'Sign Up',
+                                                    unregisteredPlaceholder: 'Get the Morning Briefing by email.',
+                                                    registeredButton: 'Sign Up',
+                                                    alreadySubscribedMessage: 'You’re already subscribed.',
+                                                    thanksMessage: 'You’ve signed up as %email%',
+                                                    emailPreferencesLinkText: 'Update your mail preferences »',
+                                                    errorMessage: 'Error submitting, please try again.',
+                                                    registeredWelcome: 'Get the Morning Briefing by email.'}
+                                            });
+
+                                            setTimeout(function(){
+                                                var widget = document.getElementById('morning-briefing-widget-eu');
+                                                var container = widget.getElementsByTagName('div')[0];
+                                                var form = widget.getElementsByTagName('form')[0];
+                                                var status = container.getAttribute('data-status');
+                                                var notify = widget.getElementsByClassName('notify-email')[0];
+
+                                                if(notify !== undefined){
+
+                                                    var origtext = notify.getAttribute('placeholder');
+                                                    var newtext = 'Please enter your email address';
+                                                    var button = container.getElementsByTagName('button')[0];
+
+                                                    widget.setAttribute('class','clearfix');
+
+                                                    notify.addEventListener('mouseover',function(){
+                                                        notify.setAttribute('placeholder',newtext);
+                                                    });
+
+                                                    notify.addEventListener('mouseout',function(){
+                                                        notify.setAttribute('placeholder',origtext);
+                                                    });
+
+                                                    notify.addEventListener('focus',function(){
+                                                        notify.setAttribute('placeholder','');
+                                                    });
+
+                                                }
+
+                                                if(form !== undefined){
+                                                    notify.addEventListener('keyup',function(){
+                                                        form.setAttribute('class','dirtyform');
+                                                    });
+                                                    container.setAttribute('class','not-signedin');
+                                                } else {
+                                                    container.setAttribute('class','signedin');
+                                                }
+                                            },2000);
+
+                                        });
+                                    });
+                                </script>
+
+                            </article>
+
+
+                            <!-- California Today -->
+
+                            <article class="story theme-summary nythpGeoCalTodayPromo" data-rank="2" data-collection-renderstyle="HpSumMediumMediaHigh" data-start-time="" data-end-time="">
+                                <figure class="media photo medium-thumb">
+                                    <div class="image">
+                                        <a href="http://www.nytimes.com/newsletters/california-today"><img src="https://static01.nyt.com/packages/images/email/assets/california_news.jpg" alt=""></a>
+                                    </div>
+                                </figure>
+                                <h2 class="story-heading"><a href="http://www.nytimes.com/newsletters/california-today">California Today</a></h2>
+                                <p class="summary">The news and stories that matter to Californians, delivered weekday mornings.</p>
+
+
+                                <div id="g-graphic" class="nythp-morning-briefing-email-promo notification-widget">
+                                    <div id="california-today-widget"></div>
+                                </div>
+
+                                <script>
+                                    require.config({
+                                        paths: {
+                                            'nytint/email-subscriber' : 'https://int.nyt.com/applications/email-subscriber/client'
+                                        }
+                                    });
+
+                                    require(['foundation/main'], function() {
+                                        require(['nytint/email-subscriber'], function(Subscriber) {
+                                            Subscriber.setup({
+                                                containerId: 'california-today-widget',
+                                                productCode: 'CA',
+                                                /* elementToHideOnSubscribe: '.nythp-morning-briefing-email-promo', */
+                                                text: {unregisteredButton: 'Sign Up',
+                                                    unregisteredPlaceholder: 'Get California Today by email.',
+                                                    registeredButton: 'Sign Up',
+                                                    alreadySubscribedMessage: 'You’re already subscribed.',
+                                                    thanksMessage: 'You’ve signed up as %email%',
+                                                    emailPreferencesLinkText: 'Update your mail preferences »',
+                                                    errorMessage: 'Error submitting, please try again.',
+                                                    registeredWelcome: 'Get California Today by email.'}
+                                            });
+
+                                            setTimeout(function(){
+                                                var widget = document.getElementById('california-today-widget');
+                                                var container = widget.getElementsByTagName('div')[0];
+                                                var form = widget.getElementsByTagName('form')[0];
+                                                var status = container.getAttribute('data-status');
+                                                var notify = widget.getElementsByClassName('notify-email')[0];
+
+                                                if(notify !== undefined){
+
+                                                    var origtext = notify.getAttribute('placeholder');
+                                                    var newtext = 'Please enter your email address';
+                                                    var button = container.getElementsByTagName('button')[0];
+
+                                                    widget.setAttribute('class','clearfix');
+
+                                                    notify.addEventListener('mouseover',function(){
+                                                        notify.setAttribute('placeholder',newtext);
+                                                    });
+
+                                                    notify.addEventListener('mouseout',function(){
+                                                        notify.setAttribute('placeholder',origtext);
+                                                    });
+
+                                                    notify.addEventListener('focus',function(){
+                                                        notify.setAttribute('placeholder','');
+                                                    });
+
+                                                }
+
+                                                if(form !== undefined){
+                                                    notify.addEventListener('keyup',function(){
+                                                        form.setAttribute('class','dirtyform');
+                                                    });
+                                                    container.setAttribute('class','not-signedin');
+                                                } else {
+                                                    container.setAttribute('class','signedin');
+                                                }
+                                            },2000);
+
+                                        });
+                                    });
+                                </script>
+                            </article>
+
+                            <article class="story theme-summary nythpGeoMBPromo" id="topnews-100000004906098" data-story-id="100000004906098" data-rank="2" data-collection-renderstyle="HpSumMediumMediaHigh" data-start-time="" data-end-time="">
+                                <figure class="media photo medium-thumb">
+                                    <div class="image">
+                                        <a href="https://www.nytimes.com/newsletters/morning-briefing"><img src="https://static01.nyt.com/images/2017/05/25/us/25usbriefing/25usbriefing-mediumFlexible177-v2.jpg" alt=""></a>
+                                    </div>
+                                </figure>
+                                <h2 class="story-heading"><a href="https://www.nytimes.com/newsletters/morning-briefing">Morning Briefing</a></h2>
+                                <p class="summary">The news and stories that matter. Delivered to your inbox Monday through Friday.</p>
+
+
+                                <div id="g-graphic" class="nythp-morning-briefing-email-promo notification-widget">
+                                    <div id="morning-briefing-widget"></div>
+                                </div>
+
+                                <script>
+                                    require.config({
+                                        paths: {
+                                            'nytint/email-subscriber' : 'https://int.nyt.com/applications/email-subscriber/client'
+                                        }
+                                    });
+
+                                    require(['foundation/main'], function() {
+                                        require(['nytint/email-subscriber'], function(Subscriber) {
+                                            Subscriber.setup({
+                                                containerId: 'morning-briefing-widget',
+                                                productCode: 'NN',
+                                                /* elementToHideOnSubscribe: '.nythp-morning-briefing-email-promo', */
+                                                text: {unregisteredButton: 'Sign Up',
+                                                    unregisteredPlaceholder: 'Get the Morning Briefing by email.',
+                                                    registeredButton: 'Sign Up',
+                                                    alreadySubscribedMessage: 'You’re already subscribed.',
+                                                    thanksMessage: 'You’ve signed up as %email%',
+                                                    emailPreferencesLinkText: 'Update your mail preferences »',
+                                                    errorMessage: 'Error submitting, please try again.',
+                                                    registeredWelcome: 'Get the Morning Briefing by email.'}
+                                            });
+
+                                            setTimeout(function(){
+                                                var widget = document.getElementById('morning-briefing-widget');
+                                                var container = widget.getElementsByTagName('div')[0];
+                                                var form = widget.getElementsByTagName('form')[0];
+                                                var status = container.getAttribute('data-status');
+                                                var notify = widget.getElementsByClassName('notify-email')[0];
+
+                                                if(notify !== undefined){
+
+                                                    var origtext = notify.getAttribute('placeholder');
+                                                    var newtext = 'Please enter your email address';
+                                                    var button = container.getElementsByTagName('button')[0];
+
+                                                    widget.setAttribute('class','clearfix');
+
+                                                    notify.addEventListener('mouseover',function(){
+                                                        notify.setAttribute('placeholder',newtext);
+                                                    });
+
+                                                    notify.addEventListener('mouseout',function(){
+                                                        notify.setAttribute('placeholder',origtext);
+                                                    });
+
+                                                    notify.addEventListener('focus',function(){
+                                                        notify.setAttribute('placeholder','');
+                                                    });
+
+                                                }
+
+                                                if(form !== undefined){
+                                                    notify.addEventListener('keyup',function(){
+                                                        form.setAttribute('class','dirtyform');
+                                                    });
+                                                    container.setAttribute('class','not-signedin');
+                                                } else {
+                                                    container.setAttribute('class','signedin');
+                                                }
+                                            },2000);
+
+                                        });
+                                    });
+                                </script>
+                            </article>
+
+                        </div>
+
+                        </div><!-- close second-column-region -->
+
+
+                    </div><!-- close b-column -->
+
+                </div><!-- close wide-b-layout -->
+
+                <div class="bottom-span-promo-region region">
+                    <div class="collection">
+                        <style>
+                            /*default display conditions*/
+                            #span-ab-bottom-au-region {
+                                /*display: none;*/
+                                display: block;
+                                position: absolute;
+                                visibility: hidden;
+                            }
+                            #span-ab-bottom-region .column.column-au-region  {
+                                /*display: none;*/
+                                display: block;
+                                position: absolute;
+                                visibility: hidden;
+                            }
+                            /*geocoded display conditions*/
+                            html.geo-country-AU #span-ab-bottom-region .column  {display: none;}
+                            html.geo-country-AU #span-ab-bottom-region .column.column-au-region  {
+                                display: block;
+                                position: inherit;
+                                visibility: visible;
+                            }
+
+                            .span-ab-layout .ab-column .split-3-layout .column:nth-of-type(1),
+                            .span-ab-layout .ab-column .split-3-layout .column:nth-of-type(4) {
+                                padding-left: 0;
+                            }
+
+                            .span-ab-layout .ab-column .split-3-layout .column:last-child,
+                            .span-ab-layout .ab-column .split-3-layout .column:nth-of-type(3),
+                            .span-ab-layout .ab-column .split-3-layout .column:nth-of-type(6) {
+                                border-right: none;
+                                padding-right: 0px;
+                            }
+
+                            #span-ab-bottom-region .section-heading-au-region { display: none; }
+                            html.geo-country-AU #span-ab-bottom-region .section-heading { display: none; }
+                            html.geo-country-AU #span-ab-bottom-region .section-heading-au-region {
+                                display: block;
+                                text-align: center;
+                            }
+                            html.geo-country-AU #span-ab-bottom-region .section-heading-au-region h2.section-heading {
+                                display: inline-block;
+                                color: #000;
+                                font-family: "nyt-franklin",helvetica,arial,sans-serif;
+                                text-transform: uppercase;
+                                font-size: 12px;
+                                font-weight: 700;
+                                letter-spacing: .5px;
+                                border-bottom: 2px solid #ccc;
+                                line-height: 15px;
+                            }
+                            html.geo-country-AU #span-ab-bottom-region .section-heading-au-region h2.section-heading:hover,
+                            html.geo-country-AU #span-ab-bottom-region .section-heading-au-region h2.section-heading:active {
+                                border-color: #222222;
+                            }
+
+                            html.geo-country-AU #span-ab-bottom-region .section-heading a {
+                                text-decoration: none;
+                                color: #000;
+                            }
+                        </style>
+
+                        <script>
+                            require(['foundation/main'], function() {
+                                require(['jquery/nyt', 'underscore/nyt'], function($, _) {
+                                    $("#span-ab-bottom-region div.split-3-layout").append($("#span-ab-bottom-au-region div.split-3-layout > div.column").addClass("column-au-region").remove());
+                                    $("#span-ab-bottom-region div.split-3-layout").prepend($('<span class="section-heading-au-region"><h2 class="section-heading"><a href="https://www.nytimes.com/section/world/australia">Australia Picks</a></h2></span>'));
+                                    var auHeight = _.max($("#span-ab-bottom-region div.split-3-layout .column.column-au-region article").map(function(i, el) { return $(el).height(); }));
+                                    $("#span-ab-bottom-region div.split-3-layout .column.column-au-region").css({"min-height": (auHeight+6)+"px"});
+                                }) })
+                        </script>
+
+
+                        <div id="span-ab-bottom-au-region" class="span-ab-bottom-region-au region"><div>
+                            <hr class="scotch-rule">
+                            <div class="split-3-layout layout theme-base"><div>
+
+                            </div>
+                                <h2 class="section-heading">
+                                </h2>
+                                <div class="column">
+                                    <article class="story theme-summary " id="topnews-100000005399553" data-story-id="100000005399553" data-rank="0" data-collection-renderstyle="HPMediumMediaHedSumDaypart">
+                                        <a href="https://www.nytimes.com/2017/08/30/world/australia/australia-same-sex-marriage-tv-ad.html">
+                                            <div class="wide-thumb">
+                                                <img src="https://static01.nyt.com/images/2017/08/31/world/australia/31oz-marriage/31oz-marriage-mediumThreeByTwo210.jpg" />
+                                            </div>
+                                        </a>
+                                        <h2 class="story-heading">
+                                            <a href="https://www.nytimes.com/2017/08/30/world/australia/australia-same-sex-marriage-tv-ad.html">What’s Going On in an Australian TV Ad Opposing Gay Marriage?</a>
+                                        </h2>
+                                        <p class="summary">
+                                            The campaign to vote “no” on legalizing same-sex marriage tries to refocus the debate on the welfare of children.        </p>
+                                    </article>
+                                </div>
+                                <div class="column">
+                                    <article class="story theme-summary " id="topnews-100000005397818" data-story-id="100000005397818" data-rank="1" data-collection-renderstyle="HPMediumMediaHedSumDaypart">
+                                        <a href="https://www.nytimes.com/2017/08/29/world/asia/sea-shepherd-whaling-japan.html">
+                                            <div class="wide-thumb">
+                                                <img src="https://static01.nyt.com/images/2017/08/30/world/29seashepherd/29seashepherd-mediumThreeByTwo210.jpg" />
+                                            </div>
+                                        </a>
+                                        <h2 class="story-heading">
+                                            <a href="https://www.nytimes.com/2017/08/29/world/asia/sea-shepherd-whaling-japan.html">Sea Shepherd Activists Halt Pursuit of Japanese Whalers</a>
+                                        </h2>
+                                        <p class="summary">
+                                            The group has called off its annual pursuit of Japanese ships in the protected Southern Ocean, saying it can’t compete with the country’s surveillance.        </p>
+                                    </article>
+                                </div>
+                                <div class="column">
+                                    <article class="story theme-summary " id="topnews-100000005396021" data-story-id="100000005396021" data-rank="2" data-collection-renderstyle="HPMediumMediaHedSumDaypart">
+                                        <a href="https://www.nytimes.com/2017/08/29/science/trigonometry-babylonian-tablet.html">
+                                            <div class="wide-thumb">
+                                                <img src="https://static01.nyt.com/images/2017/08/29/science/29TB-BABYLON1/29TB-BABYLON1-mediumThreeByTwo210.jpg" />
+                                            </div>
+                                        </a>
+                                        <h2 class="story-heading">
+                                            <a href="https://www.nytimes.com/2017/08/29/science/trigonometry-babylonian-tablet.html">Hints of Trigonometry on a 3,700-Year-Old Babylonian Tablet</a>
+                                        </h2>
+                                        <p class="summary">
+                                            Scholars have debated for decades the purpose of 60 numbers written on a small clay tablet. Two Australian mathematicians believe they have figured it out.        </p>
+                                    </article>
+                                </div>
+                                <div class="collection">
+                                </div></div></div></div></div>
+                </div><!-- close bottom-span-promo-region -->
+
+                <div id="span-ab-bottom-region" class="span-ab-bottom-region region">
+                    <hr class="scotch-rule" />
+                    <div class="split-3-layout layout theme-base">
+                        <h2 class="section-heading">
+                        </h2>
+                        <div class="column">
+                            <article class="story theme-summary " id="topnews-100000005395156" data-story-id="100000005395156" data-rank="0" data-collection-renderstyle="HPMediumMediaHedSumDaypart">
+                                <a href="https://www.nytimes.com/2017/08/30/sports/olympics/munich-olympic-massacre-1972-memorial-israeli-athletes.html">
+                                    <div class="wide-thumb">
+                                        <img src="https://static01.nyt.com/images/2017/08/30/multimedia/30MUNIC-alpha/30MUNICweb2-mediumThreeByTwo210.jpg" />
+                                    </div>
+                                </a>
+                                <h2 class="story-heading">
+                                    <a href="https://www.nytimes.com/2017/08/30/sports/olympics/munich-olympic-massacre-1972-memorial-israeli-athletes.html">In Munich, a Tribute to Israeli Athletes</a>
+                                </h2>
+                                <p class="summary">
+                                    “There are no happier people, no more satisfied people, than us,” said the wife of a victim who pressed for a worthy memorial.        </p>
+                            </article>
+                        </div>
+                        <div class="column">
+                            <article class="story theme-summary " id="topnews-100000005399019" data-story-id="100000005399019" data-rank="1" data-collection-renderstyle="HPMediumMediaHedSumDaypart">
+                                <a href="https://www.nytimes.com/interactive/2017/08/31/travel/what-to-do-36-hours-in-glasgow-scotland.html">
+                                    <div class="wide-thumb">
+                                        <img src="https://static01.nyt.com/images/2017/08/31/travel/31HOURS-GLASGOW1/31HOURS-GLASGOW1-mediumThreeByTwo210.jpg" />
+                                        <div class="media-action-overlay">
+                                            <i class="icon sprite-icon icon-media-interactive-16x16-ffffff"></i>
+                                        </div>
+                                    </div>
+                                </a>
+                                <h2 class="story-heading">
+                                    <a href="https://www.nytimes.com/interactive/2017/08/31/travel/what-to-do-36-hours-in-glasgow-scotland.html">36 Hours in Glasgow</a>
+                                </h2>
+                                <p class="summary">
+                                    This historic city, known for its Art Nouveau flourishes, also has a blossoming modern side, with daring new buildings and bars.        </p>
+                            </article>
+                        </div>
+                        <div class="column">
+                            <article class="story theme-summary " id="topnews-100000005367249" data-story-id="100000005367249" data-rank="2" data-collection-renderstyle="HPMediumMediaHedSumDaypart">
+                                <a href="https://www.nytimes.com/2017/08/31/books/review/jesmyn-ward-by-the-book.html">
+                                    <div class="wide-thumb">
+                                        <img src="https://static01.nyt.com/images/2017/09/03/books/review/0903-BKS-ByTheBook/0903-BKS-ByTheBook-mediumThreeByTwo210-v3.jpg" />
+                                    </div>
+                                </a>
+                                <h2 class="story-heading">
+                                    <a href="https://www.nytimes.com/2017/08/31/books/review/jesmyn-ward-by-the-book.html">Jesmyn Ward: By the Book</a>
+                                </h2>
+                                <p class="summary">
+                                    The author of, most recently, “Sing, Unburied, Sing” is a self-described “reading glutton.”        </p>
+                            </article>
+                        </div>
+                    </div>
+                </div><!-- close span-ab-bottom-region -->
+
+            </section><!-- close top-news -->
+
+        </div><!-- close ab-column -->
+
+        <div class="c-column column">
+
+            <div id="Middle" class="ad middle-ad hidden nocontent robots-nocontent"></div>
+
+            <div class="region c-column-top-span-region">
+
+
+            </div><!-- close c-column-top-span-region -->
+
+            <section class="opinion">
+
+                <div class="region opinion-c-col-top-region">
+                    <div class="collection">
+                        <section class="opinion">
+                            <h2 class="section-heading"><a href="http://www.nytimes.com/pages/opinion/index.html">The Opinion Pages</a>
+                            </h2>
+                        </section></div>
+                </div> <!-- close opinion-c-col-top-region -->
+
+                <div class="layout split-layout">
+
+                    <div class="column">
+                        <div class="region opinion-c-col-left-region">
+                            <div class="collection">
+                                <article class="story theme-summary" id="topnews-100000005396602" data-story-id="100000005396602" data-rank="0" data-collection-renderstyle="HpSumXSMedia">
+
+                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/31/opinion/trump-north-korea.html">What Trump Meant to Say</a></h2>
+
+                                    <div class="small-thumb">
+                                        <a href="https://www.nytimes.com/2017/08/31/opinion/trump-north-korea.html"><img src="https://static01.nyt.com/images/2017/09/01/world/01blinken-inyt/01blinken-inyt-blogSmallThumb.jpg" alt=""></a>
+                                    </div>
+
+                                    <p class="byline">By ANTONY J. BLINKEN </p>
+
+                                    <p class="summary">
+                                        The president’s rogue-cop routine has serious foreign policy consequences.    </p>
+
+
+                                </article>
+
+                            </div>
+                            <div class="collection headlines">
+                                <ul class="theme-news-headlines">
+                                    <li>
+                                        <article class="story" id="topnews-100000005400536" data-story-id="100000005400536" data-rank="0" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/31/opinion/voting-reform-illinois-texas.html">Editorial: On Voting Reforms, Follow Illinois, Not Texas</a> </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" id="topnews-100000005401080" data-story-id="100000005401080" data-rank="1" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/31/opinion/trump-harvey-storm-army.html">Blow: Trump Raises an Army</a> <time class="timestamp" datetime="2017-08-31" data-eastern-timestamp="3:21 AM" data-utc-timestamp="1504164084">3:21 AM ET</time></h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" id="topnews-100000005401128" data-story-id="100000005401128" data-rank="2" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/interactive/2017/08/31/opinion/columnists/yemen-famine-cholera.html">Kristof: The Photos the U.S. and Saudi Arabia Don’t Want You to See</a> </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" id="topnews-100000005400586" data-story-id="100000005400586" data-rank="3" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/31/opinion/hurricanes-climate-capitalists-wealth-.html">Stephens: Hurricanes, Climate and the Capitalist Offset</a> <time class="timestamp" datetime="2017-08-31" data-eastern-timestamp="3:21 AM" data-utc-timestamp="1504164083">3:21 AM ET</time></h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="collection headlines">
+                                <ul class="theme-news-headlines">
+                                    <li>
+                                        <article class="story" id="topnews-100000003665755" data-story-id="100000003665755" data-rank="0" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.facebook.com/nytopinion">Join us on Facebook »</a> </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="column">
+                        <div class="region opinion-c-col-right-region">
+                            <div class="collection">
+                                <article class="story theme-summary" id="topnews-100000005398365" data-story-id="100000005398365" data-rank="0" data-collection-renderstyle="HpSumXSMedia">
+
+                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/31/opinion/america-nuclear-buildup.html">Risky Nuclear Buildup</a></h2>
+
+                                    <div class="small-thumb">
+                                        <a href="https://www.nytimes.com/2017/08/31/opinion/america-nuclear-buildup.html"><img src="https://static01.nyt.com/images/2017/08/31/opinion/31rollo/31rollo-blogSmallThumb.jpg" alt=""></a>
+                                    </div>
+
+                                    <p class="byline">By STUART ROLLO <time class="timestamp" datetime="2017-08-31" data-eastern-timestamp="3:21 AM" data-utc-timestamp="1504164083">3:21 AM ET</time></p>
+
+                                    <p class="summary">
+                                        It’s not just North Korea. Plans to upgrade America’s nuclear arsenal are also contributing to global instability.    </p>
+
+
+                                </article>
+
+                            </div>
+                            <div class="collection headlines">
+                                <ul class="theme-news-headlines">
+                                    <li>
+                                        <article class="story" id="topnews-100000005399880" data-story-id="100000005399880" data-rank="0" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/opinion/texas-farmers-floods-planning.html">A Texas Farmer on Harvey, Bad Planning and Runaway Growth</a> </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" id="topnews-100000005400373" data-story-id="100000005400373" data-rank="1" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/opinion/google-influence-think-tanks.html">Google’s Disturbing Influence Over Think Tanks</a> </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" id="topnews-100000005400487" data-story-id="100000005400487" data-rank="2" data-collection-renderstyle="HpHeadline">
+                                            <h2 class="story-heading"><i class="icon"></i><a href="https://www.nytimes.com/2017/08/30/opinion/trump-osteen-harvey-church.html">The Cheap Prosperity Gospel of Trump and Osteen</a> </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+
+                </div> <!-- close split-layout -->
+
+                <div class="region opinion-c-col-bottom-region">
+                    <div class="collection">
+                        <style>
+
+
+                            .c-column.column section.opinion div time.timestamp{
+                                display:none;
+                            }
+
+
+                        </style><style>
+                        .c-column.column section.opinion div p.theme-comments{
+                            display:none;
+                        }
+
+
+
+                    </style></div>
+                </div> <!-- close opinion-c-col-bottom-region -->
+
+            </section> <!-- close opinion -->
+
+            <section class="user-subscriptions">
+
+                <h2 class="section-heading visually-hidden">User Subscriptions</h2>
+
+                <div class="collection insider-collection">
+                    <div id="times-insider-subscription" class="times-insider-subscription hidden">
+                        <ul class="theme-news-headlines">
+                            <li>
+                                <article class="story">
+                                    <h2 class="story-heading">
+                                        <a href="https://www.nytimes.com/2017/08/26/insider/syphilis-health-investigators-sisterhood-of-sleuths.html">A Sisterhood of Sleuths</a>
+                                    </h2>
+                                </article>
+                            </li>
+                            <li>
+                                <article class="story">
+                                    <h2 class="story-heading">
+                                        <a href="https://www.nytimes.com/2017/08/30/insider/the-sodden-haunted-fields-of-flanders.html">The Sodden, Haunted Fields of Flanders</a>
+                                    </h2>
+                                </article>
+                            </li>
+                            <li>
+                                <article class="story">
+                                    <h2 class="story-heading">
+                                        <a href="https://www.nytimes.com/2017/08/25/insider/solar-eclipse-carbondale.html">Seeing the Total Eclipse Through 28,000 Eyes</a>
+                                    </h2>
+                                </article>
+                            </li>
+                            <li>
+                                <article class="story">
+                                    <h2 class="story-heading">
+                                        <a href="https://www.nytimes.com/2017/08/24/insider/dale-chihuly-glass-artist-creativity.html">A Journalist Glimpses the Tools of an Artist’s Creativity</a>
+                                    </h2>
+                                </article>
+                            </li>
+                            <li>
+                                <article class="story">
+                                    <h2 class="story-heading">
+                                        <a href="https://www.nytimes.com/module/insider-events"></a>
+                                    </h2>
+                                </article>
+                            </li>
+                            <li>
+                                <article class="story">
+                                    <h2 class="story-heading">
+                                        <a href="https://www.nytimes.com/2017/07/28/insider/events/cryptoparty-data-security-new-york-times.html">Live Event: Discussing Data Protection at a New York Times ‘CryptoParty’</a>
+                                    </h2>
+                                </article>
+                            </li>
+                            <li>
+                                <article class="story">
+                                    <h2 class="story-heading">
+                                        <a href="https://www.nytimes.com/2017/08/09/insider/events/live-event-fall-preview-at-joes-pub.html">Live Event: ‘Fall Preview’ at Joe’s Pub</a>
+                                    </h2>
+                                </article>
+                            </li>
+                            <li>
+                                <article class="story">
+                                    <h2 class="story-heading">
+                                        <a href="https://www.nytimes.com/2017/07/14/insider/events/health-care-conference-call-what-does-policy-actually-mean-for-your-health.html">Live Event: What Do Policy Changes Actually Mean for Your Health?</a>
+                                    </h2>
+                                </article>
+                            </li>
+                            <li>
+                                <article class="story">
+                                    <h2 class="story-heading">
+                                        <a href="https://www.nytimes.com/2017/06/20/insider/events/new-york-times-podcast-club.html">Live Event: The New York Times Podcast Club</a>
+                                    </h2>
+                                </article>
+                            </li>
+                        </ul>
+                        <div class="thumb">
+                            <a href="https://www.nytimes.com/section/insider">
+                                <svg class="insider-logo" width="65" height="20" role="img" aria-label="Insider">
+                                    <image width="65" height="20" xlink:href="https://a1.nyt.com/assets/homepage/20170810-135137/images/foundation/logos/insider-logo-240x72.svg" src="https://a1.nyt.com/assets/homepage/20170810-135137/images/foundation/logos/insider-logo-240x72.png" alt="Insider" />
+                                </svg>
+                            </a>
+                        </div>
+                    </div><!--close times-insider-subscription -->
+                </div><!-- close collection -->
+
+                <div class="collection">
+                    <div id="times-premier-crossword-subscription" class="times-premier-crossword-subscription hidden">
+                        <div class="layout split-layout">
+                            <div class="column">
+                                <div class="collection insider-collection">
+                                    <article class="story">
+                                        <h3 class="kicker">
+                                            <a href="https://www.nytimes.com/section/insider">Times Insider &raquo;</a>
+                                        </h3>
+                                        <h2 class="story-heading">
+                                            <a href="https://www.nytimes.com/2017/08/26/insider/syphilis-health-investigators-sisterhood-of-sleuths.html">A Sisterhood of Sleuths</a>
+                                        </h2>
+                                    </article>
+                                </div>
+                            </div><!-- close column -->
+                            <div class="column">
+                                <div class="collection crosswords-collection">
+                                    <article class="story">
+                                        <h3 class="kicker">
+                                            <a href="https://www.nytimes.com/crosswords">The Crossword &raquo;</a>
+                                        </h3>
+                                        <h2 class="story-heading">
+                                            <a href="https://www.nytimes.com/crosswords">Play Today&rsquo;s Puzzle </a>
+                                        </h2>
+                                        <div class="thumb">
+                                            <a href="https://www.nytimes.com/crosswords">
+                                                <img src="https://static01.nyt.com/images/crosswords/crosswords_30x30.png" alt="" />
+                                            </a>
+                                        </div>
+                                    </article>
+                                </div>
+                            </div>
+                        </div><!--close TimesPremiercrossword -->
+                    </div><!--close times-premier-crossword-subscription -->
+                </div><!-- close collection -->
+
+                <div class="collection">
+                    <div id="crossword-subscription" class="crossword-subscription hidden">
+                        <div class="layout split-layout">
+                            <div class="column">
+                                <div class="collection crosswords-collection">
+                                    <article class="story">
+                                        <h3 class="kicker">
+                                            <a href="https://www.nytimes.com/crosswords">The Crossword &raquo;</a>
+                                        </h3>
+                                        <h2 class="story-heading">
+                                            <a href="https://www.nytimes.com/crosswords">Play Today&rsquo;s Puzzle </a>
+                                        </h2>
+                                        <div class="thumb">
+                                            <a href="https://www.nytimes.com/crosswords">
+                                                <img src="https://static01.nyt.com/images/crosswords/crosswords_30x30.png" alt="" />
+                                            </a>
+                                        </div>
+                                    </article>
+                                </div>
+                            </div>
+                            <div class="column">
+                                <div class="collection crosswords-collection">
+                                    <article class="story">
+                                        <h3 class="kicker">
+                                            <a href="http://wordplay.blogs.nytimes.com">Wordplay &raquo;</a>
+                                        </h3>
+                                    </article>
+                                </div>
+                            </div><!-- close column -->
+                        </div><!-- close layout -->
+                    </div><!-- close crossword-subscription -->
+                </div><!--close collection -->
+
+            </section><!-- close user-subscriptions -->
+
+            <div id="HPMiddle" class="ad hpmiddle-ad nocontent robots-nocontent"></div>
+
+            <div class="region c-column-middle-span-region">
+
+                <div class="collection">
+                    <link rel="stylesheet" type="text/css" href="https://int.nyt.com/apps/portals/assets/portal-6d57ae10010ddcfe80e975e769c6947e.css"/>
+
+                    <style type="text/css">
+                        /*HIDE WATCHING HEADER*/
+                        .portal-container>header { display: none }
+                    </style>
+
+                    <div id="nytint-hp-watching">
+                        <div class="portal-container">
+                            <header class="portal-header">
+                                <h4>Watching</h4>
+                            </header>
+                            <div class="portal-posts-frame expanded"></div>
+                            <footer class="portal-footer"></footer>
+                        </div>
+                    </div>
+
+                    <script type="text/javascript">
+                        require(['foundation/main'], function() {
+                            require(['homepage/main', 'https://int.nyt.com/apps/portals/assets/portal/app-31573ba689b023d9e52c26c6d6aa32ab.js'
+                            ], function() {
+                                require(['portal/app'], function(Portal) {
+
+                                    var opts = {
+                                        env: 'production_published',
+                                        matchHeight: {
+                                            match: '.span-ab-layout.layout > .ab-column',
+                                            container: '.c-column.column',
+                                            maxHeight: 2000
+                                        }
+                                    }
+
+                                    if (window.location.search.indexOf('portal_variant=watchingNoScroll') !== -1) {
+                                        opts.variation = 'simple';
+                                        opts.poll = false;
+                                        opts.limit = 20;
+                                    }
+
+                                    var watching = Portal.create('#nytint-hp-watching', opts);
+                                });
+                            });
+                        });
+                    </script>
+
+                    <!-- HpPrototype: WatchingEnabled: DO NOT REMOVE -->
+                </div>
+
+            </div><!-- close c-column-middle-span-region -->
+
+            <div class="region c-column-above-moth-fixed-region">
+
+
+            </div><!-- close c-column-above-moth-fixed-region -->
+
+            <div class="region c-column-above-moth-region">
+
+
+            </div><!-- close c-column-above-moth-region -->
+
+        </div><!-- close c-column -->
+
+    </div><!-- close span-ab-layout -->
+
+    <section id="paid-post-five-pack" class="paid-post-five-pack hidden nocontent robots-nocontent">
+        <h2 class="section-heading">From Our Advertisers</h2>
+        <ul class="story-menu">
+            <li id="PaidPostFivePack1" class="story-menu-item ad"></li>
+            <li id="PaidPostFivePack2" class="story-menu-item ad"></li>
+            <li id="PaidPostFivePack3" class="story-menu-item ad"></li>
+            <li id="PaidPostFivePack4" class="story-menu-item ad"></li>
+            <li id="PaidPostFivePack5" class="story-menu-item ad"></li>
+        </ul>
+    </section>
+    <div id="HPBreak" class="ad hpbreak-ad nocontent robots-nocontent hidden"></div>
+
+    <div id="video-player-region" class="video-player-region region">
+        <div class="collection">
+            <div id="video-module-loader" class="loader-container video-section-loader-container">
+                <div class="loader loader-t-logo-32x32-ecedeb-ffffff"><span class="visually-hidden">Loading...</span></div>
+            </div>
+            <section id="video-section"
+                     class="video-section invisible"
+                     data-playlist-id="1194811622188"
+                     data-api-token="cE97ArV7TzqBzkmeRVVhJ8O6GWME2iG_bRvjBTlNb4o."
+                     data-player-id="2640832222001"
+                     data-publisher-id="1749339200">
+                <header class="section-header">
+                    <h2 class="section-heading"><a class="times-video-link" href="https://www.nytimes.com/video">times<span>video</span></a></h2>
+                    <a href="https://www.nytimes.com/video?src=vidm" class="user-action explore-all-videos-link"> explore all videos &raquo;</a>
+                </header>
+                <div class="column a-column">
+                    <article class="story">
+                        <figure class="media video video-player" aria-label="media" role="group">
+                            <span class="visually-hidden">Video Player</span>
+                            <img src="" class="poster" alt="" />
+                            <div class="video-player-container"></div>
+                            <div class="media-action-overlay"></div>
+                            <div class="sharetools video-sharetools"
+                                 data-shares="email|,facebook|,twitter|,embed|,show-all|"
+                                 data-url=""
+                                 data-title=""
+                                 data-description=""
+                                 data-content-type="video">
+                            </div>
+                            <figcaption class="credit"></figcaption>
+                        </figure>
+                    </article>
+                </div>
+                <div class="column b-column">
+                    <div id="video-playlist-container" class="video-playlist-container">
+                        <ul id="video-playlist" class="video-playlist"></ul>
+                    </div>
+                </div> <!-- end b-column -->
+            </section>
+        </div>
+    </div><!-- close video-player-region -->
+
+    <section class="inside-nyt">
+        <div class="inside-nyt-region region">
+            <h2 class="section-heading">Inside Nytimes.com</h2>
+            <div id="inside-nyt-browser" class="inside-nyt-browser">
+                <div class="navigation-control">
+                    <button class="button previous deactivated">
+                        <div class="arrow arrow-left">
+                            <span class="visually-hidden">Go to the previous story</span>
+                            <div class="arrow-conceal"></div>
+                        </div>
+                    </button>
+                    <button class="button next">
+                        <div class="arrow arrow-right">
+                            <span class="visually-hidden">Go to the next story</span>
+                            <div class="arrow-conceal"></div>
+                        </div>
+                    </button>
+                </div>
+                <div class="carousel">
+                    <ol class="menu layout-horizontal theme-story">
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/section/theater">Theater</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005387208" data-rank="0" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/30/theater/oh-my-sweet-land-amir-nizar-zuabi.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/09/03/arts/27SWEETLAND1/27SWEETLAND1-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">The Kitchen Is Her Stage</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/pages/opinion/index.html">Opinion</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005396481" data-rank="1" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/29/opinion/transgender-trump-chelsea-manning.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/08/29/opinion/29kirchickWeb/29kirchickWeb-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">When Transgender Trumps Treachery</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/section/technology">Technology</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005396461" data-rank="2" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/30/technology/doxxing-protests.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/08/30/business/30DOXXING5/30DOXXING5-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">How ‘Doxxing’ Became a Tool</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/pages/dining/index.html">Food</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005388364" data-rank="3" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://cooking.nytimes.com/recipes/12965-spaghetti-carbonara">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2013/12/17/dining/recipes-spaghetticarbonara-copy/recipes-spaghetticarbonara-copy-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">How to Make the Best Spaghetti Carbonara</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/pages/opinion/index.html">Opinion</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005397970" data-rank="4" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/29/opinion/harvey-houston-schools-teachers.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/08/29/opinion/29danielsSub/29danielsSub-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">I Teach in Houston. I’m Worried for My Students.</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/section/science">Science</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005398035" data-rank="5" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/30/science/nova-stars-korea.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/08/31/science/31TB-NOVA1/31TB-NOVA1-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">The Mystery of a Vanished Star</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/section/arts/design">Art & Design</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005391869" data-rank="0" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/30/arts/design/berkshires-elizabeth-king-helen-frankenthaler-clark-art-mass-moca.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/09/01/arts/01BERKSHIRETOUR1/01BERKSHIRETOUR1-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">Berkshire Tour of Art</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/pages/opinion/index.html">Opinion</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005396484" data-rank="1" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/30/opinion/corporate-tax-cuts-jobs.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/08/30/opinion/30anderson/30anderson-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">The Corporate Tax Cut Myth</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/spotlight/times-tips">Smarter Living</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005390050" data-rank="2" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/30/smarter-living/how-to-deal-with-all-the-bites-and-stings-of-summer.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/08/24/smarter-living/24Bites-smarterLiving-slide-21DI/24Bites-smarterLiving-slide-21DI-mediumSquare149-v2.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">How to Deal With the Stings of Summer</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/section/fashion">Fashion & Style</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005396095" data-rank="3" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/30/fashion/labor-day-weekend-sales-openings.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/08/31/fashion/31SCOUTING1combo/31SCOUTING1combo-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">Finding Labor Day Weekend’s Best Sales</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/pages/opinion/index.html">Opinion</a></h2>
+
+                                <article class="story theme-summary no-thumb" data-story-id="100000005399960" data-rank="4" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/30/opinion/washington-remains-united-behind-nato.html">
+                                        <h2 class="story-heading">Washington Remains United Behind NATO</h2>
+                                        <p class="summary">There is a strong consensus that a renaissance of NATO offers the best hope to confront our current threats.</p>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+                        <li>
+                            <section>
+                                <h2 class="section-heading"><a href="https://www.nytimes.com/section/us">U.S.</a></h2>
+
+                                <article class="story theme-summary" data-story-id="100000005399999" data-rank="5" data-collection-renderstyle="Moth">
+                                    <a class="story-link" href="https://www.nytimes.com/2017/08/30/us/fire-ants-harvey-hurricane-storm.html">
+                                        <div class="wide-thumb">
+                                            <img src="https://static01.nyt.com/images/2017/08/31/us/31xp-fireants/merlin-to-scoop-126550571-982068-mediumSquare149.jpg" alt="">
+                                        </div>
+                                        <h2 class="story-heading">Hazard in Houston? Fire Ants</h2>
+                                    </a>
+                                </article>
+
+                            </section>
+                        </li>
+
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <div id="HPMidLeader" class="ad hpmidleader-ad nocontent robots-nocontent"></div>
+
+    <div class="span-ab-layout layout">
+
+        <div class="ab-column column">
+
+            <hr class="scotch-rule" />
+
+            <section class="well">
+                <div class="region well-region">
+                    <h2 class="section-heading visually-hidden">Sections</h2>
+
+
+                    <div class="split-3-layout layout theme-base">
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/world/index.html">World &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005392389" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/world/canada/canada-climate-change-arctic.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/world/americas/31CanadaChurchill1/churchill-slide-GEXA-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Churchill Journal: Canadian Town, Isolated After Losing Rail Link, ‘Feels Held Hostage’        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005399498" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/world/asia/north-korea-south-korea-missile-pictures-bomb.html">
+                                                    After Missile Tests, North and South Korea Wage War of Pictures        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005401178" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/world/americas/brazil-amazon-mining-temer-environmentalists-judge.html">
+                                                    Brazilian Judge Stymies Plan to Allow Mining in Amazon Region        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/business/index.html">Business Day &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005399538" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/technology/personaltech/future-smartphone-camera-augmented-reality.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/business/31techfix/31techfix-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Tech Fix: The Smartphone’s Future: It’s All About the Camera        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005400786" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/health/gene-therapy-cancer.html">
+                                                    F.D.A. Approves First Gene-Altering Leukemia Treatment, Costing $475,000        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005396254" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/business/media/nfl-six-second-commercials.html">
+                                                    Six-Second Commercials Are Coming to N.F.L. Games on Fox        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column last-column">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/opinion/index.html">Opinion &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005400487" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/opinion/trump-osteen-harvey-church.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/30/opinion/30butlerWeb/30butlerWeb-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Op-Ed Contributor: The Cheap Prosperity Gospel of Trump and Osteen        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005400536" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/31/opinion/voting-reform-illinois-texas.html">
+                                                    Editorial: On Voting Reforms, Follow Illinois, Not Texas        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005401080" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/31/opinion/trump-harvey-storm-army.html">
+                                                    Charles M. Blow: Trump Raises an Army        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                    </div><!-- close split-3-layout -->
+
+
+                    <div class="split-3-layout layout theme-base">
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/us">U.S. &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005401006" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/us/small-towns-harvey.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/us/31towns4/31towns4-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    As Houston Looks to Recover, Small Towns Now Bear the Brunt        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005401457" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/interactive/2017/08/30/us/houston-flood-rescue-cries-for-help.html">
+                                                    Thousands Cried for Help as Houston Flooded        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005399973" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/us/port-arthur-flooding.html">
+                                                    Port Arthur Faces Harvey Flooding Disaster: ‘Our Whole City Is Underwater’        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/technology/index.html">Technology &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005399538" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/technology/personaltech/future-smartphone-camera-augmented-reality.html">
+
+
+                                                <h3 class="story-heading">
+                                                    Tech Fix: The Smartphone’s Future: It’s All About the Camera        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005396461" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/technology/doxxing-protests.html">
+                                                    How ‘Doxxing’ Became a Mainstream Tool in the Culture Wars        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005393341" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/technology/kalanick-benchmark-uber-delaware.html">
+                                                    Kalanick’s Feud With Benchmark Goes to Arbitration for Now, Judge Rules        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column last-column">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/arts/index.html">Arts &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005385152" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/arts/design/maiolino-museum-of-contemporary-art.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/09/01/arts/01MAIOLINO1/01MAIOLINO1-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    art review: Weekend in Los Angeles: That Touch of Brazil        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005398883" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/arts/television/uk-gbbo-great-british-bake-off-channel-4.html">
+                                                    ‘Great British Bake Off’ Is Still a Treat for Many Viewers        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005399033" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/books/review-cuz-danielle-allen.html">
+                                                    Books of The Times: ‘Cuz’ Mourns a Loss and Denounces a System        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                    </div><!-- close split-3-layout -->
+
+
+                    <div class="split-3-layout layout theme-base">
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/politics/index.html">Politics &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005401238" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/us/politics/us-aid-pakistan-terror.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/us/31dc-diplo/31dc-diplo-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    U.S. Gives Military Assistance to Pakistan, With Strings Attached        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005401018" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/us/politics/trump-obamacare-enrollment-markets-subsidies.html">
+                                                    Trump Administration Wants to Stabilize Health Markets but Won’t Say How        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005400924" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/us/politics/hurricane-sandy-relief-fact-check.html">
+                                                    Fact Check: Was 2013 Hurricane Sandy Relief Package ‘Full of Pork’?        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/fashion">Fashion & Style &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005398042" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/31/fashion/jean-paul-goude-desigual.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/fashion/31UNBUTTONED-1/31UNBUTTONED-1-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Unbuttoned: Desigual Turns to Jean-Paul Goude for a Makeover        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005396488" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/fashion/uncle-brother-catskills-gavin-brown.html">
+                                                    A Catskills Art Scene Makes a Splash With Free Curry        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005373132" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/fashion/aura-photography-radiant-human.html">
+                                                    Me Time: Aura Photographs: Selfies for the New Age Set        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column last-column">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/movies">Movies &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005389037" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/29/movies/amid-gung-ho-mentality-stunt-deaths-renew-a-debate-over-safety.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/30/arts/29STUNT3/29STUNT3-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Amid ‘Gung-Ho Mentality,’ Stunt Deaths Renew a Debate Over Safety        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005364809" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/28/movies/venice-film-festival-opening-stars-matt-damon-kristen-wiig.html">
+                                                    Venice Film Festival Opening Stars Matt Damon and Kristen Wiig        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005395796" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/28/movies/texas-chain-saw-massacre-tobe-hooper-appraisal.html">
+                                                    An Appraisal: In ‘Texas Chain Saw Massacre,’ Sympathy for the Devil        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                    </div><!-- close split-3-layout -->
+
+
+                    <div class="split-3-layout layout theme-base">
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/nyregion">New York &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005386266" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/31/nyregion/new-york-today-hurricanes-in-nyc-harvey-tropical-storm.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/nyregion/31NYTODAY1/31NYTODAY1-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    New York Today: New York Today: Reflecting on Harvey, in the Northeast        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005400160" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/nyregion/ordering-review-of-statues-puts-de-blasio-in-tricky-spot.html">
+                                                    Ordering Review of Statues Puts de Blasio in Tricky Spot        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005398633" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/nyregion/instagram-places-new-york-travel.html">
+                                                    New York City’s Newest Hot Spot? Check Instagram        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/sports/index.html">Sports &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005399955" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/sports/espn-ed-cunningham-football-concussions.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/sports/31BRAINSweb1/31BRAINSweb1-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    ESPN Football Analyst Walks Away, Disturbed by Brain Trauma on Field        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005401613" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/31/sports/tennis/alexander-zverev-borna-coric-us-open.html">
+                                                    Two Zverevs Take the Court in Queens, and Only One Advances        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005395156" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/sports/olympics/munich-olympic-massacre-1972-memorial-israeli-athletes.html">
+                                                    In Munich, a Tribute to Israeli Athletes and Families’ Persistence        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column last-column">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/theater/index.html">Theater &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005387208" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/theater/oh-my-sweet-land-amir-nizar-zuabi.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/09/03/arts/27SWEETLAND1/27SWEETLAND1-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    The Kitchen Is Her Stage. (It Could Actually Be Your Kitchen.)        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005364092" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/theater/eavesdropping-on-warhol-and-capote.html">
+                                                    Eavesdropping on Warhol and Capote        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005360538" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/29/theater/great-comet-broadway-race.html">
+                                                    Race, Money and Broadway: How ‘Great Comet’ Burned Out        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                    </div><!-- close split-3-layout -->
+
+
+                    <div class="split-3-layout layout theme-base">
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/science">Science &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005343497" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/video/science/100000005343497/forty-years-of-voyager.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/29/multimedia/Voyager-Thumb1/Voyager-Thumb1-thumbStandard.png" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Forty Years of Voyager        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005398035" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/science/nova-stars-korea.html">
+                                                    Trilobites: Casting Light on Mystery of a Star That Vanished After 14 Days        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005396021" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/29/science/trigonometry-babylonian-tablet.html">
+                                                    Trilobites: Hints of Trigonometry on a 3,700-Year-Old Babylonian Tablet        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/obituaries">Obituaries &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005401130" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/sports/ncaabasketball/villanova-coach-rollie-massimino-dead.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/30/obituaries/30massimino1/30massimino1-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Rollie Massimino, 82, Dies; Rode Dark Horse Villanova to Basketball Glory        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005398288" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/sports/basketball/jud-heathcote-dead-coached-michigan-state-to-basketball-title.html">
+                                                    Jud Heathcote, 90, Dies; Coached Michigan State to Basketball Title        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005399785" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/business/david-tang-dead-fashion-retailer.html">
+                                                    David Tang, Fashion Retailer and Raconteur, Dies at 63        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column last-column">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/arts/television">Television &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005398883" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/arts/television/uk-gbbo-great-british-bake-off-channel-4.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/arts/31BAKEOFF-ROUNDUP/31BAKEOFF-ROUNDUP-thumbStandard-v2.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    ‘Great British Bake Off’ Is Still a Treat for Many Viewers        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005367164" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/24/arts/television/the-deuce-hbo-david-simon.html">
+                                                    ‘The Deuce’ Recalls Sex and Sleaze in 1970s Times Square        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005396266" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/interactive/2017/08/29/watching/fall-tv-sf-promo.html">
+                                                    Watching: Your Catch-Up Guide to the Best Shows Returning This Fall        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                    </div><!-- close split-3-layout -->
+
+
+                    <div class="split-3-layout layout theme-base">
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/health/index.html">Health &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005400786" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/health/gene-therapy-cancer.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/science/31GENE3/31GENE3-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    F.D.A. Approves First Gene-Altering Leukemia Treatment, Costing $475,000        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005390415" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/29/business/economy/home-health-care-work.html">
+                                                    Economic Scene: Home Health Care: Shouldn’t It Be Work Worth Doing?        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005395934" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/28/health/fda-stem-cell.html">
+                                                    F.D.A. Cracks Down on ‘Unscrupulous’ Stem Cell Clinics        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/travel">Travel &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000004599829" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/travel/peaceful-island-indonesia.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/09/10/travel/10gili1/30gili1-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Next Stop: This Indonesian Island Is a Respite From Bali. At Least for Now.        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005388668" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/interactive/2017/08/29/travel/what-to-do-36-hours-in-trieste-italy.html">
+                                                    36 Hours: 36 Hours in Trieste, Italy        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005385852" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/28/travel/kodiak-travel-photography.html">
+                                                    Photo Essay: Our Stunning World        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column last-column">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/books">Books &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005399033" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/books/review-cuz-danielle-allen.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/31/books/31bookallen2/31bookallen2-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Books of The Times: ‘Cuz’ Mourns a Loss and Denounces a System        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005396584" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/29/books/review-my-absolute-darling-gabriel-tallent.html">
+                                                    Books of The Times: A Heroine in the Mold of Huck and Scout        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005395901" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/28/books/review-john-le-carre-legacy-of-spies.html">
+                                                    Books of The Times: George Smiley and Other Old Friends Return in John le Carré’s ‘A Legacy of Spies’        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                    </div><!-- close split-3-layout -->
+
+
+                    <div class="split-3-layout layout theme-base">
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/education">Education &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005337043" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/interactive/2017/08/24/us/affirmative-action.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/03/us/affirmative-action-in-colleges-and-representation-of-blacks-and-hispanics-1503525136789/affirmative-action-in-colleges-and-representation-of-blacks-and-hispanics-1503525136789-thumbStandard-v5.png" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Even With Affirmative Action, Blacks and Hispanics Are More Underrepresented at Top Colleges Than 35 Years Ago        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005348802" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/24/technology/coding-boot-camps-close.html">
+                                                    As Coding Boot Camps Close, the Field Faces a Reality Check        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005384528" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/22/opinion/washington-lee-university-trump-nationalism.html">
+                                                    On Campus: My University Is Named for Robert E. Lee. What Now?        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/dining/index.html">Food &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005387948" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/29/dining/restaurant-wish-list-pete-wells.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/30/dining/30WISH3/30WISH3-thumbStandard-v2.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Critic’s Notebook: A Wish List for New Restaurants        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005390036" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/dining/mashed-potato-salad-recipe.html">
+                                                    A Good Appetite: An Accidentally Creamier, Fluffier Potato Salad        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005314050" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/29/dining/opentable-restaurant-reservations.html">
+                                                    OpenTable Began a Revolution. Now It’s a Power Under Siege.        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column last-column">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/opinion/index.html#sundayreview">Sunday Review &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005391244" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/interactive/2017/08/25/opinion/sunday/worst-and-best-places-to-be-gay.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/24/opinion/sunday/worst-and-best-places-to-be-gay-1503633763145/worst-and-best-places-to-be-gay-1503633763145-thumbStandard.png" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Op-Ed Columnist: The Worst (and Best) Places to Be Gay in America        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005392272" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/26/opinion/sunday/memorize-poems-poetry-education.html">
+                                                    Molly Worthen: Memorize That Poem!        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005388249" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/26/opinion/sunday/obamacare-universal-health-coverage.html">
+                                                    Editorial: Looking Beyond the Obamacare Debate to Improve Health Care        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                    </div><!-- close split-3-layout -->
+
+
+                    <div class="split-3-layout layout theme-base">
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/realestate/index.html">Real Estate &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005386638" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/realestate/weston-conn-quiet-and-wooded-with-top-notch-schools.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/09/03/realestate/03LIVING-WESTON-slide-537E/03LIVING-WESTON-slide-537E-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Living In: Weston, Conn.: Quiet and Wooded, With Top-Notch Schools        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005390514" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/realestate/house-hunting-in-bali.html">
+                                                    International Real Estate: House Hunting in ... Bali        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005395929" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/realestate/900000-homes-in-colorado-pennsylvania-and-vermont.html">
+                                                    What You Get: $900,000 Homes in Colorado, Pennsylvania and Vermont        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/upshot">The Upshot &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005396126" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/interactive/2017/08/29/upshot/statues-quiz.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/26/upshot/up-statue-Lee/up-statue-Lee-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Which Statues Need to Come Down? You Decide        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005393332" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/interactive/2017/08/29/upshot/harvey-rainfall-where-you-live.html">
+                                                    Houston May Get 50 Inches of Rain. How Long Does It Take Your City to Get That Much?        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005395922" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/28/upshot/markets-are-signaling-that-hurricane-harvey-wont-crush-the-economy.html">
+                                                    Pricing a Disaster: Markets Are Signaling That Hurricane Harvey Won’t Crush the Economy        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column last-column">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/magazine">Magazine &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005393258" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/magazine/how-to-get-rich-in-trumps-washington.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/09/03/magazine/03lobbyists1/03lobbyists1-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Feature: How to Get Rich in Trump’s Washington        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005381661" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/interactive/2017/08/24/magazine/usopen-federer-nadal-backhand-wonder-year.html">
+                                                    U.S. Open: How Roger Federer Upgraded His Game        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005389041" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/magazine/my-nanny-has-a-gambling-problem-can-i-fire-her.html">
+                                                    The Ethicist: My Nanny Has a Gambling Problem. Can I Fire Her?        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                    </div><!-- close split-3-layout -->
+
+
+                    <div class="split-3-layout layout theme-base">
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/pages/automobiles/index.html">Automobiles &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005398865" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/29/business/ford-driverless-pizza-delivery-dominos.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/30/business/30FORD1/30FORD1-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    There’s a Pizza Delivery in Ford’s Future, by Driverless Car        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005385761" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/24/automobiles/wheels/pebble-beach-concours-delegance-car-auction.html">
+                                                    Wheels: Bidding Before California Car Show Suggests Collectible Market Is Healthy        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005391881" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/25/business/volkswagen-engineer-prison-diesel-cheating.html">
+                                                    Volkswagen Engineer Gets Prison in Diesel Cheating Case        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column ">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/t-magazine">T Magazine &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005365534" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/t-magazine/travel/sullivan-county-narrowsburg-livingston-manor-callicoon-guide.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/30/t-magazine/sullivan-slide-VBE5-copy/sullivan-slide-VBE5-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Wanderlust: What to Do (and Where to Stay) in the Western Catskills        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005392498" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/29/t-magazine/charlottesville-art-robert-longo-toyin-ojih-odutola-sanford-biggers.html">
+                                                    T Agitprop: 5 Artists Respond to: Charlottesville        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005397209" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/29/t-magazine/fashion/maggie-marilyn-hewitt-clothing-designer.html">
+                                                    On the Verge: Person to Know: A Nonconformist New Zealand Designer        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                        <div class="column last-column">
+
+                            <section>
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/insider">Times Insider &raquo;</a>
+                                </h2>
+                                <ul>
+                                    <li>
+                                        <article class="story theme-summary" data-story-id="100000005400594" data-rank="0" data-collection-renderstyle="HpHedThumbWell">
+
+                                            <a class="story-link" href="https://www.nytimes.com/2017/08/30/insider/events/game-of-thrones-conference-call-new-york-times.html">
+
+                                                <div class="thumb">
+                                                    <img src="https://static01.nyt.com/images/2017/08/30/insider/30insider-event-thrones-image/30insider-event-thrones-image-thumbStandard.jpg" alt="" />
+                                                </div>
+
+                                                <h3 class="story-heading">
+                                                    Conference Call, Sept. 6: Live Event: Discuss ‘Game of Thrones’ With The New York Times        </h3>
+                                            </a>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005399053" data-rank="1" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/insider/the-sodden-haunted-fields-of-flanders.html">
+                                                    Picturing the First World War: The Sodden, Haunted Fields of Flanders        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                    <li>
+                                        <article class="story" data-story-id="100000005396519" data-rank="2" data-collection-renderstyle="HpHedThumbWell">
+                                            <h2 class="story-heading">
+                                                <a href="https://www.nytimes.com/2017/08/30/insider/newsbook-column-explainer-book-review.html">
+                                                    When the News Begs for a Book: Behind the Newsbook Column        </a>
+                                            </h2>
+                                        </article>
+                                    </li>
+                                </ul>
+                            </section>
+
+                        </div> <!-- close column -->
+
+
+                    </div><!-- close split-3-layout -->
+
+                </div>
+            </section><!-- close well section -->
+
+        </div><!-- close ab-column -->
+
+        <div class="c-column column">
+
+
+            <section class="real-estate">
+                <div class="layout split-layout theme-base">
+                    <div class="column">
+                        <div class="region real-estate-left-region">
+
+                            <div class="collection">
+                                <h2 class="section-heading">
+                                    <a href="https://www.nytimes.com/section/realestate">Real Estate &raquo;</a>
+                                </h2>
+                                <article class="story theme-summary" id="topnews-100000005395929" data-story-id="100000005395929" data-rank="0" data-collection-renderstyle="HpSectionSumSmallMedia">
+
+                                    <h3 class="kicker">What You Get </h3>
+
+                                    <h2 class="story-heading"><a href="https://www.nytimes.com/2017/08/30/realestate/900000-homes-in-colorado-pennsylvania-and-vermont.html">$900,000 Homes in Colorado, Pennsylvania and Vermont</a></h2>
+
+                                    <p class="byline">By TIM McKEOUGH </p>
+
+                                    <div class="thumb">
+                                        <a href="https://www.nytimes.com/2017/08/30/realestate/900000-homes-in-colorado-pennsylvania-and-vermont.html"><img src="https://static01.nyt.com/images/2017/09/03/realestate/03WYG-slide-FF9B/03WYG-slide-FF9B-thumbStandard.jpg" alt=""></a>
+                                    </div>
+
+                                    <p class="summary">
+                                        A renovated midcentury-modern home in Denver, a 1907 stone house in Philadelphia and a lakeside retreat in Ferrisburgh.    </p>
+
+
+                                </article>
+
+                            </div>
+                            <div class="collection">
+                                <ul class="theme-module-headlines">
+                                    <li><article class="story" data-collection-renderstyle="HpHeadline"><h2 class="story-heading"><a href="http://www.nytimes.com/real-estate/find-a-home">Search for Homes for Sale or Rent</a></h2></article></li>
+
+                                    <li><article class="story" data-collection-renderstyle="HpHeadline"><h2 class="story-heading"><a href="https://www.nytimes.com/real-estate/mortgage-calculator">Mortgage Calculator</a></h2></article></li></ul>
+
+                            </div>
+
+                        </div><!-- close real-estate-left-region -->
+                    </div>
+                    <div class="column">
+                        <div class="region real-estate-right-region">
+                            <div class="collection">
+                                <div id="HPmodule-RE2-alternate-content"><div></div>
+                                    <div class="collection">
+                                    </div></div></div>
+                            <div id="hpmodulere2" class="ad hpmodulere2-ad nocontent robots-nocontent"></div>
+                        </div><!-- close real-estate-right-region -->
+                    </div>
+                </div>
+            </section>
+
+
+            <section id="recommendations" class="recommendations">
+                <div class="tabs-container">
+                    <ul class="tabs">
+                        <li data-type="most-emailed" class="most-emailed-tab"><a href="https://www.nytimes.com/trending/">Most Emailed</a></li><li data-type="most-viewed" class="most-viewed-tab"><a href="https://www.nytimes.com/gst/mostpopular.html">Most Viewed</a></li><li data-type="trending" class="trending-tab"><a href="http://www.nytimes.com/trending/">Trending</a></li><li data-type="recommended" class="recommended-tab"><a href="https://www.nytimes.com/recommendations">Recommended for you</a></li>
+                    </ul>
+                </div><!-- end tabs-container -->
+
+                <div class="tab-content most-emailed">
+                    <div class="loader"></div>
+                </div>
+                <div class="tab-content most-viewed">
+                    <div class="loader"></div>
+                </div>
+                <div class="tab-content trending">
+                    <div class="loader"></div>
+                </div>
+                <div class="tab-content recommended">
+                    <div class="loader"></div>
+                </div>
+
+                <div id="recommendations-module-loader" class="loader-container">
+                    <div class="loader loader-t-logo-32x32-ecedeb-ffffff"><span class="visually-hidden">Loading...</span></div>
+                </div>
+            </section>
+
+            <div id="Box1" class="ad box1-ad nocontent robots-nocontent"></div>
+            <div id="HPBottom1" class="ad hpbottom1-ad nocontent robots-nocontent"></div>
+
+        </div><!-- close c-column -->
+
+    </div><!-- close span-ab-layout -->
+
+    <div id="HPSponLink" class="ad hpsponlink-ad nocontent robots-nocontent"></div>
+    <div id="Bottom8" class="ad bottom8-ad nocontent robots-nocontent"></div>
+    <div id="Bottom9" class="ad bottom9-ad nocontent robots-nocontent"></div>
+    <div class="search-overlay"></div>
+    </main><!-- close main -->
+    <section id="site-index" class="site-index">
+        <header class="section-header">
+            <p class="user-action"><a href="https://www.nytimes.com/">Go to Home Page &raquo;</a></p>
+            <h2 class="section-heading">
+                <span class="visually-hidden">Site Index</span>
+                <a id="site-index-branding-link" href="https://www.nytimes.com/">
+                    <span class="visually-hidden">The New York Times</span>
+                </a>
+            </h2>
+            <script>window.magnum.writeLogo('small', 'https://a1.nyt.com/assets/homepage/20170810-135137/images/foundation/logos/', '', '', 'standard', 'site-index-branding-link', '');</script>
+        </header>
+
+        <nav id="site-index-navigation" class="site-index-navigation" role="navigation">
+            <h2 class="visually-hidden">Site Index Navigation</h2>
+            <div class="split-6-layout layout">
+
+
+                <div class="column">
+                    <h3 class="menu-heading">News</h3>
+                    <ul class="menu">
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/world/index.html">World</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/national/index.html">U.S.</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/politics/index.html">Politics</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/nyregion/index.html">N.Y.</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/business/index.html">Business</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/technology/index.html">Tech</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/section/science">Science</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/health/index.html">Health</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/sports/index.html">Sports</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/education/index.html">Education</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/obituaries/index.html">Obituaries</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/todayspaper/index.html">Today's Paper</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/corrections/index.html">Corrections</a>
+                        </li>
+
+
+                    </ul>
+                </div><!-- close column -->
+
+
+                <div class="column">
+                    <h3 class="menu-heading">Opinion</h3>
+                    <ul class="menu">
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/opinion/index.html">Today's Opinion</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/opinion/index.html#columnists">Op-Ed Columnists</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/opinion/index.html#editorials">Editorials</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/opinion/index.html#contributing">Contributing Writers</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/opinion/index.html#op-ed">Op-Ed Contributors</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/opinion/index.html#opinionator">Opinionator</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/opinion/index.html#letters">Letters</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/opinion/index.html#sundayreview">Sunday Review</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/opinion/index.html#takingNote">Taking Note</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/roomfordebate">Room for Debate</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/video/opinion">Video: Opinion</a>
+                        </li>
+
+
+                    </ul>
+                </div><!-- close column -->
+
+
+                <div class="column">
+                    <h3 class="menu-heading">Arts</h3>
+                    <ul class="menu">
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/arts/index.html">Today's Arts</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/arts/design/index.html">Art & Design</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/books/index.html">Books</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/arts/dance/index.html">Dance</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/movies/index.html">Movies</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/arts/music/index.html">Music</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/arts/television/index.html">Television</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/theater/index.html">Theater</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/video/arts">Video: Arts</a>
+                        </li>
+
+
+                    </ul>
+                </div><!-- close column -->
+
+
+                <div class="column">
+                    <h3 class="menu-heading">Living</h3>
+                    <ul class="menu">
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/automobiles/index.html">Automobiles</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/crosswords/">Crossword</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/dining/index.html">Food</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/education/index.html">Education</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/fashion/index.html">Fashion & Style</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/health/index.html">Health</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/section/jobs">Jobs</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/magazine/index.html">Magazine</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/section/realestate">Real Estate</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/section/t-magazine">T Magazine</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/section/travel">Travel</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/fashion/weddings/index.html">Weddings & Celebrations</a>
+                        </li>
+
+
+                    </ul>
+                </div><!-- close column -->
+
+
+                <div class="column">
+                    <h3 class="menu-heading">Listings & More</h3>
+                    <ul class="menu">
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/section/reader-center">Reader Center</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/ref/classifieds/">Classifieds</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/marketing/tools-and-services/">Tools & Services</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/topics/">Times Topics</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/interactive/blogs/directory.html">Blogs</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/pages/multimedia/index.html">Multimedia</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://lens.blogs.nytimes.com/">Photography</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/video">Video</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/store/?&t=qry542&utm_source=nytimes&utm_medium=HPB&utm_content=hp_browsetree&utm_campaign=NYT-HP&module=SectionsNav&action=click&region=TopBar&version=BrowseTree&contentCollection=NYT%20Store&contentPlacement=2&pgtype=Homepage">NYT Store</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/times-journeys/?utm_source=nytimes&utm_medium=HPLink&utm_content=hp_browsetree&utm_campaign=NYT-HP">Times Journeys</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/seeallnav">Subscribe</a>
+                        </li>
+
+
+                        <li>
+                            <a href="https://www.nytimes.com/membercenter">Manage My Account</a>
+                        </li>
+
+
+                        <li>
+                            <a href="http://www.nytco.com">NYTCo</a>
+                        </li>
+
+
+                    </ul>
+                </div><!-- close column -->
+
+
+                <div class="column last-column">
+
+                    <h3 class="menu-heading">Subscribe</h3>
+
+                    <ul class="menu primary-menu">
+                        <li class="menu-label">Subscribe</li>
+                        <li class="home-delivery">
+                            <i class="icon sprite-icon"></i>
+                            <a class="nyt-home-delivery" href="https://www.nytimes.com/hdleftnav">Home Delivery</a>
+                        </li>
+                        <li class="digital-subscriptions">
+                            <i class="icon sprite-icon"></i>
+                            <a class="digital-subscription" href="https://www.nytimes.com/digitalleftnav">Digital Subscriptions</a>
+                        </li>
+                        <li class="nyt-crossword last-item">
+                            <i class="icon sprite-icon"></i>
+                            <a id="nyt-crossword" href="https://www.nytimes.com/crosswords/index.html">Crossword</a>
+                        </li>
+                    </ul>
+
+                    <ul class="menu secondary-menu">
+
+                        <li class="email-newsletters">
+                            <a href="https://www.nytimes.com/marketing/newsletters">Email Newsletters</a>
+                        </li>
+                        <li>
+                            <a href="https://myaccount.nytimes.com/mem/tnt.html">Alerts</a>
+                        </li>
+                        <li class="gift-subscription">
+                            <a href="https://www.nytimes.com/giftleftnav">Gift Subscriptions</a>
+                        </li>
+                        <li>
+                            <a href="https://www.nytimes.com/corporateleftnav">Corporate Subscriptions</a>
+                        </li>
+                        <li>
+                            <a href="https://www.nytimes.com/educationleftnav">Education Rate</a>
+                        </li>
+
+                    </ul>
+                    <ul class="menu secondary-menu">
+                        <li>
+                            <a href="https://www.nytimes.com/services/mobile/index.html">Mobile Applications</a>
+                        </li>
+                        <li>
+                            <a href="http://eedition.nytimes.com/cgi-bin/signup.cgi?cc=37FYY">Replica Edition</a>
+                        </li>
+
+                    </ul>
+
+                </div><!-- close column -->
+
+            </div><!-- close split-6-layout -->
+
+        </nav><!-- close nav -->
+
+    </section><!-- close site-index -->
+
+    <footer id="page-footer" class="page-footer" role="contentinfo">
+        <nav>
+            <h2 class="visually-hidden">Site Information Navigation</h2>
+            <ul>
+                <li>
+                    <a href="https://www.nytimes.com/content/help/rights/copyright/copyright-notice.html" itemprop="copyrightNotice">
+                        &copy; <span itemprop="copyrightYear">2017</span><span itemprop="copyrightHolder provider sourceOrganization" itemscope itemtype="http://schema.org/Organization" itemid="http://www.nytimes.com"><span itemprop="name"> The New York Times Company</span><meta itemprop="tickerSymbol" content="NYSE NYT"/></span>
+                    </a>
+                </li>
+                <li class="wide-viewport-item"><a href="https://www.nytimes.com/ref/membercenter/help/infoservdirectory.html">Contact Us</a></li>
+                <li class="wide-viewport-item"><a href="http://www.nytco.com/careers">Work With Us</a></li>
+                <li class="wide-viewport-item"><a href="http://nytmediakit.com/">Advertise</a></li>
+                <li class="wide-viewport-item"><a href="https://www.nytimes.com/content/help/rights/privacy/policy/privacy-policy.html#pp">Your Ad Choices</a></li>
+                <li><a href="https://www.nytimes.com/privacy">Privacy</a></li>
+                <li><a href="https://www.nytimes.com/ref/membercenter/help/agree.html" itemprop="usageTerms">Terms of Service</a></li>
+                <li class="wide-viewport-item last-item"><a href="https://www.nytimes.com/content/help/rights/sale/terms-of-sale.html">Terms of Sale</a></li>
+            </ul>
+        </nav>
+        <nav class="last-nav">
+            <h2 class="visually-hidden">Site Information Navigation</h2>
+            <ul>
+                <li><a href="http://spiderbites.nytimes.com">Site Map</a></li>
+                <li><a href="https://www.nytimes.com/membercenter/sitehelp.html">Help</a></li>
+                <li><a href="https://myaccount.nytimes.com/membercenter/feedback.html">Site Feedback</a></li>
+                <li class="wide-viewport-item last-item"><a href="https://www.nytimes.com/subscriptions/Multiproduct/lp5558.html?campaignId=37WXW">Subscriptions</a></li>
+            </ul>
+        </nav>
+
+        <div id="mobile-banner" class="mobile-banner hidden">
+            <a class="banner-message" href="https://mobile.nytimes.com/">View Mobile Version</a>
+        </div>
+
+        <div id="dfp-perf-test" class="ad hidden"></div>
+    </footer>
+</div><!-- close page -->
+</div><!-- close shell -->
+<script>
+    require(['foundation/main'], function () {
+        require(['homepage/main']);
+        require(['jquery/nyt', 'foundation/views/page-manager'], function ($, pageManager) {
+            if (window.location.search.indexOf('disable_tagx') > 0) {
+                return;
+            }
+            $(document).ready(function () {
+                require(['https://a1.nyt.com/analytics/tagx-simple.min.js'], function () {
+                    pageManager.trackingFireEventQueue();
+                });
+            });
+        });
+    });
+</script>
+<!--esi
+<esi:include src="/appconfig/https/show-modal.js" />
+-->
+
+<div id="Inv1" class="ad inv1-ad hidden"></div>
+<div id="Inv2" class="ad inv2-ad hidden"></div>
+<div id="Inv3" class="ad inv3-ad hidden"></div>
+<div id="ab1" class="ad ab1-ad hidden"></div>
+<div id="ab2" class="ad ab2-ad hidden"></div>
+<div id="ab3" class="ad ab3-ad hidden"></div>
+<div id="prop1" class="ad prop1-ad hidden"></div>
+<div id="prop2" class="ad prop2-ad hidden"></div>
+<div id="Anchor" class="ad anchor-ad hidden"></div>
+<div id="ADX_CLIENTSIDE" class="ad adx-clientside-ad hidden"></div>
+</body>
+</html>

--- a/test/benchmark/run.php
+++ b/test/benchmark/run.php
@@ -1,0 +1,29 @@
+<?php
+
+require __DIR__ . "/../../vendor/autoload.php";
+
+$iterations = isset($argv[1]) ? $argv[1] : 100;
+
+$html5 = new Masterminds\HTML5();
+$content = file_get_contents(__DIR__ . '/example.html');
+$dom = $html5->loadHTML($content);
+
+$samples = array();
+for ($i = 0; $i < $iterations; $i++) {
+    $t = microtime(true);
+    $dom = $html5->loadHTML($content);
+    $samples[] = microtime(true) - $t;
+}
+$time = array_sum($samples) / count($samples);
+echo "Loading: " . ($time * 1000) . "\n";
+
+$samples = array();
+for ($i = 0; $i < $iterations; $i++) {
+    $t = microtime(true);
+    $html5->saveHTML($dom);
+    $samples[] = microtime(true) - $t;
+}
+$time = array_sum($samples) / count($samples);
+echo "Writing: " . ($time * 1000) . "\n";
+
+exit(0);


### PR DESCRIPTION
this is an alternative version of https://github.com/Masterminds/html5-php/pull/130 (thanks @MichaelHeerklotz)

It takes the same approach but it does not change method signatures

I've added also a basic benchmark:

Before:

```
Loading: 234.88136053085
Writing: 29.471714496613
```

After:
```
Loading: 189.25537729263
Writing: 30.500716209412
```
Performance change looks the same (20%)
@MichaelHeerklotz can you try it on your dataset?