### PR TITLE
Add DOM extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         }
     ],
     "require" : {
+        "ext-dom": "*",
         "ext-libxml" : "*",
         "php" : ">=5.3.0"
     },


### PR DESCRIPTION
Even if the DOM extension is usually included in packaged versions of PHP, technically, a PHP build may not have it installed or enabled. Adding a constraint in Composer could prevent runtime issues.

Don't close to ignore this PR if you don't think it's useful :) .