### PR TITLE
Improve the Tokenizer performance

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -124,8 +124,10 @@ class Tokenizer
         // Character reference
         $this->characterReference();
 
+        $tok = $this->scanner->current();
+
         // Parse tag
-        if ($this->scanner->current() === '<') {
+        if ($tok === '<') {
             // Any buffered text data can go out now.
             $this->flushBuffer();
 
@@ -138,10 +140,11 @@ class Tokenizer
                 // This always returns false.
                 || $this->parseError("Illegal tag opening")
                 || $this->characterData();
+
+            $tok = $this->scanner->current();
         }
 
         // Handle end of document
-        $tok = $this->scanner->current();
         $this->eof($tok);
 
         // Parse character


### PR DESCRIPTION
After working on https://github.com/Masterminds/html5-php/pull/146, I realized the Tokenizer was the next bottleneck of the parser. This PR improves its performance by inlining text parsing and removing some Scanner::current calls.

As you can see in https://blackfire.io/profiles/8d809c0b-1a22-476e-9800-756d7e0440ba/graph (current 2.x branch), there are two main bottlenecks: `Scanner::current` (which is fixed by removing the InputStream in https://github.com/Masterminds/html5-php/pull/146) and `Tokenizer::consumeData`.

This PR improves the state of `Tokenizer::consumeData` by doing two things:
- removing unnecessary calls to `Scanner::current`;
- inlining the logic dedicated to characters parsing, as it is by far the most important execution path of the consumeData method;

This creates a small duplication of code (which is not even really a duplication, as the code is optimized for the context of consumeData), but it greatly improves performances:

**Test script**

> Note: I changed the fixture file between this PR and https://github.com/Masterminds/html5-php/pull/146 to use one which should be closer to real cases. This is why times are different.

```php
require __DIR__.'/../vendor/autoload.php';

$html = file_get_contents(__DIR__.'/fixture.html');

$start = microtime(true);
$total = 100;

for ($i = 0; $i < $total; $i++) {
    $parser = new \Masterminds\HTML5();
    $parser->loadHTMLFragment($html);
}

$time = microtime(true) - $start;

echo 'Total time: '.round($time * 1000)."ms\n";
echo 'Time per iteration: '.round(($time * 1000) / $total, 2)."ms\n";
```

**Simple time measurement**

*Before*:

```
Total time: 2104ms
Time per iteration: 21.04ms
```

*After*:

```
Total time: 1784ms
Time per iteration: 17.84ms
```

**Blackfire analysis**

> Note that Blackfire introduces an overhead on functions and methods calls, which enhance the difference. This is why I also did simple time measurements.

- *Before*: https://blackfire.io/profiles/2c67ffe2-a6f8-44b7-805e-db84d03f3757/graph
- *After*: https://blackfire.io/profiles/90d2000b-8384-405c-b28e-abb5ae06f8af/graph