### PR TITLE
Improve performance by moving sequence matching

### DIFF
--- a/src/HTML5/Parser/Scanner.php
+++ b/src/HTML5/Parser/Scanner.php
@@ -62,6 +62,30 @@ class Scanner
     }
 
     /**
+     * Check if upcomming chars match the given sequence.
+     *
+     * This will read the stream for the $sequence. If it's
+     * found, this will return true. If not, return false.
+     * Since this unconsumes any chars it reads, the caller
+     * will still need to read the next sequence, even if
+     * this returns true.
+     *
+     * Example: $this->scanner->sequenceMatches('</script>') will
+     * see if the input stream is at the start of a
+     * '</script>' string.
+     *
+     * @param string $sequence
+     * @param bool $caseSensitive
+     *
+     * @return bool
+     */
+    public function sequenceMatches($sequence, $caseSensitive = true)
+    {
+        $portion = substr($this->data, $this->char, strlen($sequence));
+        return $caseSensitive ? $portion === $sequence : strcasecmp($portion, $sequence) === 0;
+    }
+
+    /**
      * Get the current position.
      *
      * @return int The current intiger byte position.

--- a/src/HTML5/Parser/Scanner.php
+++ b/src/HTML5/Parser/Scanner.php
@@ -126,9 +126,7 @@ class Scanner
      */
     public function consume($count = 1)
     {
-        for ($i = 0; $i < $count; ++ $i) {
-            $this->next();
-        }
+        $this->char += $count;
     }
 
     /**


### PR DESCRIPTION
Improve performance by moving sequence matching to the string scanner (that has a raw access to the underlying string)

Running the `test/benchmark/run.php` benchmark:
```
Before this PR:
Loading: 106.80956840515

After this PR:
Loading: 100.03929138184
```

