### PR TITLE
Optimize the handling of references when consuming data

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -121,10 +121,15 @@ class Tokenizer
      */
     protected function consumeData()
     {
-        // Character reference
-        $this->characterReference();
-
         $tok = $this->scanner->current();
+
+        if ($tok === '&') {
+            // Character reference
+            $ref = $this->decodeCharacterReference();
+            $this->buffer($ref);
+
+            $tok = $this->scanner->current();
+        }
 
         // Parse tag
         if ($tok === '<') {
@@ -301,25 +306,6 @@ class Tokenizer
         }
 
         return false;
-    }
-
-    /**
-     * Handle character references (aka entities).
-     *
-     * This version is specific to PCDATA, as it buffers data into the
-     * text buffer. For a generic version, see decodeCharacterReference().
-     *
-     * HTML5 8.2.4.2
-     */
-    protected function characterReference()
-    {
-        if ($this->scanner->current() !== '&') {
-            return false;
-        }
-
-        $ref = $this->decodeCharacterReference();
-        $this->buffer($ref);
-        return true;
     }
 
     /**


### PR DESCRIPTION
The method call to `characterReference` in all `consumeData` calls is costly.

Inlining it is quite easy, and allows avoiding reading twice the current token when there is no reference at this point.

Here is the effect on the benchmark included in this repo.

Before:
Loading: 127.32289552689
Writing: 37.346167564392

After:
Loading: 115.40209054947
Writing: 37.080278396606

That's a 9% improvement on the loading time.