### PR TITLE
Optimize consuming whitespaces

### DIFF
--- a/src/HTML5/Parser/Scanner.php
+++ b/src/HTML5/Parser/Scanner.php
@@ -223,10 +223,20 @@ class Scanner
      * Consume whitespace.
      *
      * Whitespace in HTML5 is: formfeed, tab, newline, space.
+     *
+     * @return int The length of the matched whitespaces
      */
     public function whitespace()
     {
-        return $this->doCharsWhile("\n\t\f ");
+        if ($this->char >= $this->EOF) {
+            return false;
+        }
+
+        $len = strspn($this->data, "\n\t\f ", $this->char);
+
+        $this->char += $len;
+
+        return $len;
     }
 
     /**

--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -279,7 +279,7 @@ class Tokenizer
         }
         $len = strlen($sequence);
         $this->scanner->consume($len);
-        $len += strlen($this->scanner->whitespace());
+        $len += $this->scanner->whitespace();
         if ($this->scanner->current() !== '>') {
             $this->parseError("Unclosed RCDATA end tag");
         }
@@ -779,7 +779,7 @@ class Tokenizer
         $this->scanner->whitespace();
 
         $pub = strtoupper($this->scanner->getAsciiAlpha());
-        $white = strlen($this->scanner->whitespace());
+        $white = $this->scanner->whitespace();
 
         // Get ID, and flag it as pub or system.
         if (($pub == 'PUBLIC' || $pub == 'SYSTEM') && $white > 0) {
@@ -909,7 +909,7 @@ class Tokenizer
 
         $tok = $this->scanner->next();
         $procName = $this->scanner->getAsciiAlpha();
-        $white = strlen($this->scanner->whitespace());
+        $white = $this->scanner->whitespace();
 
         // If not a PI, send to bogusComment.
         if (strlen($procName) == 0 || $white == 0 || $this->scanner->current() == false) {


### PR DESCRIPTION
Places consuming whitespaces don't care about the matched substring. They either need  its length, or nothing.
Returning only the length directly avoids computing the substring.

Loading benchmark:
Before: 115.045773983
After: 112.26821184158