### PR TITLE
Optimize the parsing of unquoted attributes

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -594,19 +594,37 @@ class Tokenizer
 
     protected function unquotedAttributeValue()
     {
-        $stoplist = "\t\n\f >";
         $val = '';
         $tok = $this->scanner->current();
-        while (0 == strspn($tok, $stoplist) && false !== $tok) {
-            if ('&' == $tok) {
-                $val .= $this->decodeCharacterReference(true);
-                $tok = $this->scanner->current();
-            } else {
-                if (strspn($tok, "\"'<=`") > 0) {
+        while (false !== $tok) {
+            switch ($tok) {
+                case "\n":
+                case "\f":
+                case ' ':
+                case "\t":
+                case '>':
+                    break 2;
+
+                case '&':
+                    $val .= $this->decodeCharacterReference(true);
+                    $tok = $this->scanner->current();
+
+                    break;
+
+                case "'":
+                case '"':
+                case '<':
+                case '=':
+                case '`':
                     $this->parseError('Unexpected chars in unquoted attribute value %s', $tok);
-                }
-                $val .= $tok;
-                $tok = $this->scanner->next();
+                    $val .= $tok;
+                    $tok = $this->scanner->next();
+                    break;
+
+                default:
+                    $val .= $this->scanner->charsUntil("\t\n\f >&\"'<=`");
+
+                    $tok = $this->scanner->current();
             }
         }
 


### PR DESCRIPTION
Instead of handling each char one by one, we read them in batch until a char for which we need a special handling (chars ending the attribute value, references and chars needing to throw an error).

I ran the loading benchmark on a modified fixture file in which I unquoted all class attributes containing a single class (this kind of replacement was the easiest to do).

Before: 116.11662387848
After: 114.08836126328

There is no difference on the unmodified benchmark, because it uses quoted attributes everywhere.
