### PR TITLE
Optimize the check for the element types during parsing

### DIFF
--- a/src/HTML5/Elements.php
+++ b/src/HTML5/Elements.php
@@ -485,10 +485,6 @@ class Elements
      */
     public static function isA($name, $mask)
     {
-        if (! static::isElement($name)) {
-            return false;
-        }
-
         return (static::element($name) & $mask) == $mask;
     }
 


### PR DESCRIPTION
`static::element($name)` already handles non-existent nodes, returning `0`, which won't match the mask (and so will return `false` as well).
This optimization removes 2 to 4 method calls per call to `isA` (which happens multiple times for end start tag, and once per end tag).

Before:
Loading: 113.14846754074
Writing: 36.459083557129

After:
Loading: 112.29121208191
Writing: 34.805071353912
