### PR TITLE
Optimize main loop

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -865,9 +865,6 @@ class Tokenizer
      */
     protected function cdataSection()
     {
-        if ('[' != $this->scanner->current()) {
-            return false;
-        }
         $cdata = '';
         $this->scanner->consume();
 

--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -721,12 +721,11 @@ class Tokenizer
      */
     protected function doctype()
     {
-        if (strcasecmp($this->scanner->current(), 'D')) {
-            return false;
-        }
         // Check that string is DOCTYPE.
-        $chars = $this->scanner->charsWhile('DOCTYPEdoctype');
-        if (strcasecmp($chars, 'DOCTYPE')) {
+        if ($this->scanner->sequenceMatches('DOCTYPE', false)) {
+            $this->scanner->consume(7);
+        } else {
+            $chars = $this->scanner->charsWhile('DOCTYPEdoctype');
             $this->parseError('Expected DOCTYPE, got %s', $chars);
 
             return $this->bogusComment('<!' . $chars);

--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -144,11 +144,11 @@ class Tokenizer
             $tok = $this->scanner->current();
         }
 
-        // Handle end of document
-        $this->eof($tok);
-
-        // Parse character
-        if (false !== $tok) {
+        if (false === $tok) {
+            // Handle end of document
+            $this->eof();
+        } else {
+            // Parse character
             switch ($this->textMode) {
                 case Elements::TEXT_RAW:
                     $this->rawText($tok);
@@ -290,18 +290,12 @@ class Tokenizer
     /**
      * If the document is read, emit an EOF event.
      */
-    protected function eof($tok)
+    protected function eof()
     {
-        if (false === $tok) {
-            // fprintf(STDOUT, "EOF");
-            $this->flushBuffer();
-            $this->events->eof();
-            $this->carryOn = false;
-
-            return true;
-        }
-
-        return false;
+        // fprintf(STDOUT, "EOF");
+        $this->flushBuffer();
+        $this->events->eof();
+        $this->carryOn = false;
     }
 
     /**
@@ -744,8 +738,9 @@ class Tokenizer
         // EOF: die.
         if (false === $tok) {
             $this->events->doctype('html5', EventHandler::DOCTYPE_NONE, '', true);
+            $this->eof();
 
-            return $this->eof($tok);
+            return true;
         }
 
         // NULL char: convert.


### PR DESCRIPTION
Here is a blackfire comparison of the loading of the fixture file used by the benchmark (I haven't profiled the whole benchmark, as repeating it 100 times leads to some functions being called thousands of millions of time, which makes the overhead of the profiler increase too much): https://blackfire.io/profiles/compare/0ad49ded-25b3-483b-aacd-3ccbc203db69/graph