### PR TITLE
Set default encoding in the DOMDocument object

### DIFF
--- a/src/HTML5/Parser/DOMTreeBuilder.php
+++ b/src/HTML5/Parser/DOMTreeBuilder.php
@@ -176,6 +176,7 @@ class DOMTreeBuilder implements EventHandler
             $dt = $impl->createDocumentType('html');
             // $this->doc = \DOMImplementation::createDocument(NULL, 'html', $dt);
             $this->doc = $impl->createDocument(null, null, $dt);
+            $this->doc->encoding = !empty($options['encoding']) ? $options['encoding'] : 'UTF-8';
         }
 
         $this->errors = array();

--- a/test/HTML5/Parser/DOMTreeBuilderTest.php
+++ b/test/HTML5/Parser/DOMTreeBuilderTest.php
@@ -52,6 +52,7 @@ class DOMTreeBuilderTest extends \Masterminds\HTML5\Tests\TestCase
         $html = '<!DOCTYPE html><html></html>';
         $doc = $this->parse($html);
 
+        $this->assertEquals('UTF-8', $doc->encoding);
         $this->assertInstanceOf('\DOMDocument', $doc);
         $this->assertEquals('html', $doc->documentElement->tagName);
         $this->assertEquals('http://www.w3.org/1999/xhtml', $doc->documentElement->namespaceURI);


### PR DESCRIPTION
Solves https://github.com/Masterminds/html5-php/issues/167 (If I am correct).