### PR TITLE
Fix Trying to access array offset on value of type null

### DIFF
--- a/test/HTML5/Parser/TokenizerTest.php
+++ b/test/HTML5/Parser/TokenizerTest.php
@@ -26,7 +26,8 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
         if (is_array($expects)) {
             $this->assertEquals($expects, $event['data'], "Event $type should equal " . print_r($expects, true) . ': ' . print_r($event, true));
         } else {
-            $this->assertEquals($expects, $event['data'][0], "Event $type should equal $expects: " . print_r($event, true));
+            $d = (is_array($event['data']) ? $event['data'][0] : null);
+            $this->assertEquals($expects, $d, "Event $type should equal $expects: " . print_r($event, true));
         }
     }
 


### PR DESCRIPTION
With PHP 7.4.0RC3
```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.0RC3
Configuration: /dev/shm/BUILD/html5-php-104443ad663d15981225f99532ba73c2f1d6b6f2/phpunit.xml.dist

...............................................................  63 / 170 ( 37%)
.......................................EE...................... 126 / 170 ( 74%)
............................................                    170 / 170 (100%)

Time: 80 ms, Memory: 6.00MB

There were 2 errors:

1) Masterminds\HTML5\Tests\Parser\TokenizerTest::testTagsWithAttributeAndMissingName
Trying to access array offset on value of type null

/dev/shm/BUILD/html5-php-104443ad663d15981225f99532ba73c2f1d6b6f2/test/HTML5/Parser/TokenizerTest.php:29
/dev/shm/BUILD/html5-php-104443ad663d15981225f99532ba73c2f1d6b6f2/test/HTML5/Parser/TokenizerTest.php:488

2) Masterminds\HTML5\Tests\Parser\TokenizerTest::testTagNotClosedAfterTagName
Trying to access array offset on value of type null

/dev/shm/BUILD/html5-php-104443ad663d15981225f99532ba73c2f1d6b6f2/test/HTML5/Parser/TokenizerTest.php:29
/dev/shm/BUILD/html5-php-104443ad663d15981225f99532ba73c2f1d6b6f2/test/HTML5/Parser/TokenizerTest.php:514

ERRORS!
Tests: 170, Assertions: 2023, Errors: 2.

```