### PR TITLE
Add <body> if it's missing

### DIFF
--- a/src/HTML5/Parser/DOMTreeBuilder.php
+++ b/src/HTML5/Parser/DOMTreeBuilder.php
@@ -322,6 +322,12 @@ class DOMTreeBuilder implements EventHandler
                 break;
         }
 
+        // Case when no <body> exists, note section on 'Anything else' below.
+        // https://html.spec.whatwg.org/multipage/parsing.html#the-after-head-insertion-mode
+        if ($this->insertMode === static::IM_AFTER_HEAD && 'head' !== $name && 'body' !== $name) {
+            $this->startTag('body');
+        }
+
         // Special case handling for SVG.
         if ($this->insertMode === static::IM_IN_SVG) {
             $lname = Elements::normalizeSvgElement($lname);
@@ -548,21 +554,20 @@ class DOMTreeBuilder implements EventHandler
 
     public function text($data)
     {
-        // XXX: Hmmm.... should we really be this strict?
+        // https://html.spec.whatwg.org/multipage/parsing.html#the-before-head-insertion-mode
         if ($this->insertMode < static::IM_IN_HEAD) {
             // Per '8.2.5.4.3 The "before head" insertion mode' the characters
-            // " \t\n\r\f" should be ignored but no mention of a parse error. This is
-            // practical as most documents contain these characters. Other text is not
-            // expected here so recording a parse error is necessary.
+            // " \t\n\r\f" should be ignored .
             $dataTmp = trim($data, " \t\n\r\f");
-            if (!empty($dataTmp)) {
-                // fprintf(STDOUT, "Unexpected insert mode: %d", $this->insertMode);
-                $this->parseError('Unexpected text. Ignoring: ' . $dataTmp);
+            if (! empty($dataTmp)) {
+                $this->startTag('head');
+                $this->endTag('head');
+                $this->startTag('body');
+            } else {
+                return;
             }
-
-            return;
         }
-        // fprintf(STDOUT, "Appending text %s.", $data);
+
         $node = $this->doc->createTextNode($data);
         $this->current->appendChild($node);
     }

--- a/test/HTML5/Html5Test.php
+++ b/test/HTML5/Html5Test.php
@@ -480,4 +480,50 @@ class Html5Test extends TestCase
         $res = $this->cycleFragment('a<![CDATA[ This <is> a test. ]]>b');
         $this->assertRegExp('|<!\[CDATA\[ This <is> a test\. \]\]>|', $res);
     }
+
+    /**
+     * Test for issue #166.
+     *
+     * @param $input
+     * @param $expected
+     *
+     * @dataProvider tagOmissionProvider
+     */
+    public function testTagOmission($input, $expected)
+    {
+        $doc = $this->html5->loadHTML($input);
+
+        $out = $this->html5->saveHTML($doc);
+
+        $this->assertRegExp("|" . preg_quote($expected, "|") . "|", $out);
+    }
+
+    /**
+     * Tag omission test cases.
+     *
+     * @return \string[][]
+     */
+    public function tagOmissionProvider()
+    {
+        return $provider = array(
+            array(
+                '<html>Hello, This is a test.<br />Does it work this time?</html>',
+                '<html><head></head><body>Hello, This is a test.<br>Does it work this time?</body></html>',
+            ),
+            // test whitespace (\n)
+            array(
+                '<!DOCTYPE html>
+<html>
+<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
+<body>
+<br>
+</body>
+</html>',
+                '<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
+<body>
+<br>
+</body>'
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Prevents `Hello, This is a text.` from being removed when parsing `<html>Hello, This is a test.<br />Does it work this time?</html>`

> A body element’s start tag may be omitted if the element is empty, or if the first thing inside the body element is not a space character or a comment, except if the first thing inside the body element is a meta, link, script, style, or template element.

https://www.w3.org/TR/2014/REC-html5-20141028/sections.html#the-body-element