### PR TITLE
Fixed memory leak in HTML5::saveHTML()

### DIFF
--- a/src/HTML5.php
+++ b/src/HTML5.php
@@ -234,6 +234,10 @@ class HTML5
         $stream = fopen('php://temp', 'wb');
         $this->save($dom, $stream, array_merge($this->defaultOptions, $options));
 
-        return stream_get_contents($stream, -1, 0);
+        $html = stream_get_contents($stream, -1, 0);
+
+        fclose($stream);
+
+        return $html;
     }
 }


### PR DESCRIPTION
With the following reproducer:

```php
<?php

use Masterminds\HTML5;

require __DIR__.'/vendor/autoload.php';

cli_set_process_title('leak');
$html = file_get_contents('https://www.php.net/');
$html5 = new HTML5();
$dom = $html5->loadHTML($html);
echo "Converting to HTML 5\n";
for ($i=0; $i < 100; $i++) {
    $html5->saveHTML($dom);
    // printf("%.2f\n", memory_get_usage(false) / 1024 / 1024);
}

printf("%.2f\n", memory_get_usage(false) / 1024 / 1024);
```

Without my patch: 8.51
With my patch:    0.67

---

Note: there are another leak, but I can not find it for now...
But this patch is **really** mandatory!