### PR TITLE
mitigate cyclic reference between output rules and the traverser objects

### DIFF
--- a/src/HTML5.php
+++ b/src/HTML5.php
@@ -212,7 +212,10 @@ class HTML5
         $trav = new Traverser($dom, $stream, $rules, $options);
 
         $trav->walk();
-
+        /*
+         * release the traverser to avoid cyclic references and allow PHP to free memory without waiting for gc_collect_cycles
+         */
+        $rules->unsetTraverser();
         if ($close) {
             fclose($stream);
         }

--- a/src/HTML5/Serializer/OutputRules.php
+++ b/src/HTML5/Serializer/OutputRules.php
@@ -182,6 +182,13 @@ class OutputRules implements RulesInterface
         return $this;
     }
 
+    public function unsetTraverser()
+    {
+        $this->traverser = null;
+
+        return $this;
+    }
+
     public function document($dom)
     {
         $this->doctype();


### PR DESCRIPTION
Alternative implementation of https://github.com/Masterminds/html5-php/pull/188

it is substantially the same but using a separate method in the concrete class...

closes https://github.com/Masterminds/html5-php/pull/188