### PR TITLE
fix: query parameter parsed as character entity

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -1181,16 +1181,11 @@ class Tokenizer
             return $entity;
         }
 
-        // If in an attribute, then failing to match ; means unconsume the
-        // entire string. Otherwise, failure to match is an error.
-        if ($inAttribute) {
-            $this->scanner->unconsume($this->scanner->position() - $start);
-
-            return '&';
-        }
+        // Failing to match ; means unconsume the entire string.
+        $this->scanner->unconsume($this->scanner->position() - $start);
 
         $this->parseError('Expected &ENTITY;, got &ENTITY%s (no trailing ;) ', $tok);
 
-        return '&' . $entity;
+        return '&';
     }
 }

--- a/test/HTML5/Html5Test.php
+++ b/test/HTML5/Html5Test.php
@@ -480,4 +480,13 @@ class Html5Test extends TestCase
         $res = $this->cycleFragment('a<![CDATA[ This <is> a test. ]]>b');
         $this->assertRegExp('|<!\[CDATA\[ This <is> a test\. \]\]>|', $res);
     }
+
+    public function testAnchorTargetQueryParam()
+    {
+        $res = $this->cycle("<a href=\"https://domain.com/page.php?foo=bar&target=baz\">https://domain.com/page.php?foo=bar&target=baz</a>");
+        $this->assertStringContainsString(
+            "<a href=\"https://domain.com/page.php?foo=bar&amp;target=baz\">https://domain.com/page.php?foo=bar&amp;target=baz</a>",
+            $res
+        );
+    }
 }

--- a/test/HTML5/Html5Test.php
+++ b/test/HTML5/Html5Test.php
@@ -484,7 +484,7 @@ class Html5Test extends TestCase
     public function testAnchorTargetQueryParam()
     {
         $res = $this->cycle("<a href=\"https://domain.com/page.php?foo=bar&target=baz\">https://domain.com/page.php?foo=bar&target=baz</a>");
-        $this->assertStringContainsString(
+        $this->assertContains(
             "<a href=\"https://domain.com/page.php?foo=bar&amp;target=baz\">https://domain.com/page.php?foo=bar&amp;target=baz</a>",
             $res
         );

--- a/test/HTML5/Html5Test.php
+++ b/test/HTML5/Html5Test.php
@@ -483,9 +483,9 @@ class Html5Test extends TestCase
 
     public function testAnchorTargetQueryParam()
     {
-        $res = $this->cycle("<a href=\"https://domain.com/page.php?foo=bar&target=baz\">https://domain.com/page.php?foo=bar&target=baz</a>");
+        $res = $this->cycle('<a href="https://domain.com/page.php?foo=bar&target=baz">https://domain.com/page.php?foo=bar&target=baz</a>');
         $this->assertContains(
-            "<a href=\"https://domain.com/page.php?foo=bar&amp;target=baz\">https://domain.com/page.php?foo=bar&amp;target=baz</a>",
+            '<a href="https://domain.com/page.php?foo=bar&amp;target=baz">https://domain.com/page.php?foo=bar&amp;target=baz</a>',
             $res
         );
     }


### PR DESCRIPTION
### Issue

See first commit for failing test case.

Before:
```html
<a href="https://domain.com/page.php?foo=bar&target=baz">https://domain.com/page.php?foo=bar&target=baz</a>
```

After:
```html
<a href="https://domain.com/page.php?foo=bar&amp;target=baz">https://domain.com/page.php?foo=bar&amp;⌖=baz</a>
```

### Tokenizer logic
`consumeData` reads up to `&target`:
```php
$this->text .= $this->scanner->charsUntil("<&\0");
```

On next iteration, `&` is detected as a character reference:
```php
$tok = $this->scanner->current();

if ('&' === $tok) {
    // Character reference
    $ref = $this->decodeCharacterReference();
```

### HTML spec

Input is valid HTML5 (https://validator.w3.org/#validate_by_input):
```html
<a href="https://domain.com/page.php?foo=bar&target=baz">https://domain.com/page.php?foo=bar&target=baz</a>
```

https://www.w3.org/TR/html50/syntax.html#character-references states character references must always be terminated by `;`. The current tokenizer only follows this logic for attributes.