### PR TITLE
Add .gitattributes file with export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.php_cs.dist     export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml      export-ignore
+example.php      export-ignore
+phpunit.xml.dist export-ignore
+/test            export-ignore


### PR DESCRIPTION
So we can reduce the `prefer-dist` package download size.