### PR TITLE
$tok might be false in Tokenizer.php

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -131,7 +131,10 @@ class Tokenizer
 
             $tok = $this->scanner->next();
 
-            if ('!' === $tok) {
+            if (false === $tok) {
+                // end of string
+                $this->parseError('Illegal tag opening');
+            } elseif ('!' === $tok) {
                 $this->markupDeclaration();
             } elseif ('/' === $tok) {
                 $this->endTag();


### PR DESCRIPTION
ctype_alpha(false) triggers warning ctype_alpha(): Argument of type bool will be interpreted as string in the future