### PR TITLE
Fix masterminds-html5 lib php8-1 notice return type use phpstan

### DIFF
--- a/src/HTML5/Parser/StringInputStream.php
+++ b/src/HTML5/Parser/StringInputStream.php
@@ -183,7 +183,7 @@ class StringInputStream implements InputStream
      *
      * @return string The current character.
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->data[$this->char];
     }
@@ -192,7 +192,7 @@ class StringInputStream implements InputStream
      * Advance the pointer.
      * This is part of the Iterator interface.
      */
-    public function next()
+    public function next(): void
     {
         ++$this->char;
     }
@@ -200,7 +200,7 @@ class StringInputStream implements InputStream
     /**
      * Rewind to the start of the string.
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->char = 0;
     }
@@ -210,7 +210,7 @@ class StringInputStream implements InputStream
      *
      * @return bool Whether the current pointer location is valid.
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->char < $this->EOF;
     }
@@ -324,7 +324,7 @@ class StringInputStream implements InputStream
         return false;
     }
 
-    public function key()
+    public function key(): int
     {
         return $this->char;
     }


### PR DESCRIPTION
all/libraries/composer/vendor/masterminds/html5/src/HTML5/Parser/StringInputStream.php
180 line Return type mixed of method Masterminds\HTML5\Parser\StringInputStream::current() is not covariant with tentative return type mixed of method Iterator::current().
189 line Return type mixed of method Masterminds\HTML5\Parser\StringInputStream::next() is not covariant with tentative return type void of method Iterator::next()
197 line Return type mixed of method Masterminds\HTML5\Parser\StringInputStream::rewind() is not covariant with tentative return type void of method Iterator::rewind()
207 line Return type mixed of method Masterminds\HTML5\Parser\StringInputStream::valid() is not covariant with tentative return type bool of method Iterator::valid()
327 line Return type mixed of method Masterminds\HTML5\Parser\StringInputStream::key() is not covariant with tentative return type mixed of method Iterator::key()
