### PR TITLE
Mark `<video>` tag as inline element

### DIFF
--- a/src/HTML5/Elements.php
+++ b/src/HTML5/Elements.php
@@ -185,7 +185,7 @@ class Elements
         'u' => 1,
         'ul' => 81, // NORMAL | AUTOCLOSE_P | BLOCK_TAG
         'var' => 1,
-        'video' => 65, // NORMAL | BLOCK_TAG
+        'video' => 1,
         'wbr' => 9, // NORMAL | VOID_TAG
 
         // Legacy?

--- a/test/HTML5/ElementsTest.php
+++ b/test/HTML5/ElementsTest.php
@@ -421,7 +421,6 @@ class ElementsTest extends TestCase
             'table',
             'tfoot',
             'ul',
-            'video',
         );
 
         foreach ($blockTags as $tag) {
@@ -432,6 +431,7 @@ class ElementsTest extends TestCase
             'span',
             'img',
             'label',
+            'video',
         );
         foreach ($nonBlockTags as $tag) {
             $this->assertFalse(Elements::isA($tag, Elements::BLOCK_TAG), 'Block tag test failed on: ' . $tag);


### PR DESCRIPTION
The `<video>` tag is incorrectly marked as a block element, while it's actually an inline one according to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements#list_of_inline_elements).

This causes the following problem:

```php
use Masterminds\HTML5;

$html5 = new HTML5();
$dom = $html5->loadHTMLFragment('<p>Test: <video><source src="/path/to/video.mp4" /></video></p>');
echo $html5->saveHTML($dom);
```
Result:
```html
<p>Test: </p><video><source src="/path/to/video.mp4"></video>
```

Even though having a `<video>` tag inside a `<p>` tag is valid HTML, it gets moved outside the `<p>` tag.