### PR TITLE
Continue parsing as data after invalid opening tag

### DIFF
--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -126,26 +126,25 @@ class Tokenizer
 
         // Parse tag
         if ('<' === $tok) {
-            // Any buffered text data can go out now.
-            $this->flushBuffer();
-
             $tok = $this->scanner->next();
 
-            if (false === $tok) {
-                // end of string
-                $this->parseError('Illegal tag opening');
-            } elseif ('!' === $tok) {
+            if ('!' === $tok) {
+                $this->flushBuffer();
                 $this->markupDeclaration();
             } elseif ('/' === $tok) {
+                $this->flushBuffer();
                 $this->endTag();
             } elseif ('?' === $tok) {
+                $this->flushBuffer();
                 $this->processingInstruction();
             } elseif ($this->is_alpha($tok)) {
+                $this->flushBuffer();
                 $this->tagName();
             } else {
                 $this->parseError('Illegal tag opening');
-                // TODO is this necessary ?
-                $this->characterData();
+                $this->text('<');
+                $this->scanner->unconsume();
+                return;
             }
 
             $tok = $this->scanner->current();

--- a/test/HTML5/Html5Test.php
+++ b/test/HTML5/Html5Test.php
@@ -505,6 +505,9 @@ class Html5Test extends TestCase
 
         $res = $this->cycleFragment('<style>div>div>div</style>');
         $this->assertRegExp('|div>div>div|', $res);
+
+        $res = $this->cycleFragment('<p>There is a less-than character after this word < is it rendered?</p>');
+        $this->assertRegExp('|<p>There is a less-than character after this word &lt; is it rendered\\?</p>|', $res);
     }
 
     public function testEntities()

--- a/test/HTML5/Parser/TokenizerTest.php
+++ b/test/HTML5/Parser/TokenizerTest.php
@@ -526,7 +526,7 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
         $this->assertEventError($events->get(0));
         $this->assertEventEquals('startTag', 'span', $events->get(1));
         $this->assertEventError($events->get(2));
-        $this->assertEventEquals('text', '>02', $events->get(3));
+        $this->assertEventEquals('text', '<>02', $events->get(3));
         $this->assertEventEquals('endTag', 'span', $events->get(4));
         $this->assertEventEquals('eof', null, $events->get(5));
 
@@ -957,6 +957,16 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
         $events = $this->parse('a&sup2;b');
         $this->assertEquals(2, $events->depth(), 'Events: ' . print_r($events, true));
         $this->assertEventEquals('text', 'a²b', $events->get(0));
+
+        $events = $this->parse('a < b');
+        $this->assertEquals(3, $events->depth(), 'Events: ' . print_r($events, true));
+        $this->assertEventError($events->get(0));
+        $this->assertEventEquals('text', 'a < b', $events->get(1));
+
+        $events = $this->parse('a <');
+        $this->assertEquals(3, $events->depth(), 'Events: ' . print_r($events, true));
+        $this->assertEventError($events->get(0));
+        $this->assertEventEquals('text', 'a <', $events->get(1));
     }
 
     // ================================================================


### PR DESCRIPTION
Per section [8.2.4.1](https://www.w3.org/TR/2014/REC-html5-20141028/syntax.html#data-state) of spec version 20141028:

> Parse error. Switch to the data state. Emit a U+003C LESS-THAN SIGN character token. Reconsume the current input character.

Note: the 20141028 version of the spec was used because the section numbering matches up with existing references in code. The relevant section for the living HTML5 spec is [13.2.5.1](https://html.spec.whatwg.org/multipage/parsing.html#data-state) and provides similar guidance.

fixes #250