### PR TITLE
Passing empty to ord() is deprecated in PHP 8.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php" : ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+        "phpunit/phpunit" : "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
     },
     "autoload": {
         "psr-4": {"Masterminds\\": "src"}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit
+    colors="true"
+    bootstrap="vendor/autoload.php"
+    failOnDeprecation="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+>
     <testsuites>
         <testsuite name="PHPUnit">
           <directory>test/HTML5/</directory>

--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -1208,6 +1208,10 @@ class Tokenizer
      */
     protected function is_alpha($input)
     {
+        if (empty($input)) {
+            return false;
+        }
+
         $code = ord($input);
 
         return ($code >= 97 && $code <= 122) || ($code >= 65 && $code <= 90);

--- a/src/HTML5/Parser/Tokenizer.php
+++ b/src/HTML5/Parser/Tokenizer.php
@@ -1208,7 +1208,7 @@ class Tokenizer
      */
     protected function is_alpha($input)
     {
-        if (empty($input)) {
+        if (!is_string($input) || 1 !== strlen($input)) {
             return false;
         }
 

--- a/test/HTML5/Html5Test.php
+++ b/test/HTML5/Html5Test.php
@@ -560,4 +560,12 @@ class Html5Test extends TestCase
             $this->assertContains('<a href="https://domain.com/page.php?foo=bar&amp;target=baz">https://domain.com/page.php?foo=bar&amp;target=baz</a>', $res);
         }
     }
+
+    public function testEndsWithSlash()
+    {
+        $html = '<p>Visit <a href="http://example.com/">example.com</';
+        $expected = '<p>Visit <a href="http://example.com/">example.com</a></p>';
+        $doc =  $this->html5->loadHTMLFragment($html);
+        $this->assertSame($expected, $this->html5->saveHTML($doc));
+    }
 }


### PR DESCRIPTION
Passing string which are not one byte long to `ord()` is deprecated in PHP 8.5. See https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.standard