### PR TITLE
Fix dynamic property deprecation in TraverserTest & TokenizerTest

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   phpbench:
     name: "PHPBench"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-latest"
 
     strategy:
       fail-fast: false
@@ -30,7 +30,7 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"
-        
+
       - name: Run performance tests
         run: |
           php test/benchmark/run.php 10

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   phpbench:
     name: "PHPBench"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   phpunit:
     name: "PHPUnit"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   phpunit:
     name: "PHPUnit"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-latest"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   php-cs-fixer:
     name: "php-cs-fixer"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-latest"
 
     strategy:
       fail-fast: false
@@ -25,7 +25,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-        
+
       - name: cs fix
         run: |
           wget -q https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.19.3/php-cs-fixer.phar 

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   php-cs-fixer:
     name: "php-cs-fixer"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
 
     strategy:
       fail-fast: false

--- a/test/HTML5/Parser/TokenizerTest.php
+++ b/test/HTML5/Parser/TokenizerTest.php
@@ -970,12 +970,10 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
     // ================================================================
     // Utility functions.
     // ================================================================
-    protected function createTokenizer($string, $debug = false)
+    protected function createTokenizer($string)
     {
         $eventHandler = new EventStack();
         $scanner = new Scanner($string);
-
-        $scanner->debug = $debug;
 
         return array(
             new Tokenizer($scanner, $eventHandler),
@@ -983,9 +981,9 @@ class TokenizerTest extends \Masterminds\HTML5\Tests\TestCase
         );
     }
 
-    public function parse($string, $debug = false)
+    public function parse($string)
     {
-        list($tok, $events) = $this->createTokenizer($string, $debug);
+        list($tok, $events) = $this->createTokenizer($string);
         $tok->parse();
 
         return $events;

--- a/test/HTML5/Serializer/TraverserTest.php
+++ b/test/HTML5/Serializer/TraverserTest.php
@@ -7,6 +7,11 @@ use Masterminds\HTML5\Serializer\Traverser;
 
 class TraverserTest extends \Masterminds\HTML5\Tests\TestCase
 {
+    /**
+     * @var \Masterminds\HTML5
+     */
+    protected $html5;
+
     protected $markup = '<!doctype html>
     <html lang="en">
       <head>


### PR DESCRIPTION
Avoid PHP 8.2+ deprecation warning about creation of dynamic class properties.